### PR TITLE
FTL DAGR replaced with MicroDAGR

### DIFF
--- a/cScripts/Loadouts/gearLoad.hpp
+++ b/cScripts/Loadouts/gearLoad.hpp
@@ -1,5 +1,3 @@
-// To regear add this to a item init line: _this addAction ["<t color=""#ffcc33"">ReGear</t>","[] call A3G_Loadout_fnc_ApplyLoadout;"];
-
 class CfgLoadouts {
     #include "defines.h"
     

--- a/cScripts/Loadouts/loadout_Airborn.hpp
+++ b/cScripts/Loadouts/loadout_Airborn.hpp
@@ -1,5 +1,5 @@
 /*
-GearVersionDate: 160303
+GearVersionDate: 160413
 */
 class C_ABG {                // "G"         | GRENADIER
     uniform         = "rhs_uniform_cu_ocp_1stcav";
@@ -21,7 +21,7 @@ class C_ABG {                // "G"         | GRENADIER
     items[] = {};
     magazines[] = {};
     addItemsToUniform[] = {
-        _QUA10(ACE_FieldDressing),
+        _QUA10(ACE_packingBandage),
         _QUA2(ACE_morphine),
         _QUA2(ACE_epinephrine),
         _QUA1(ACE_tourniquet),
@@ -67,10 +67,10 @@ class C_ABG {                // "G"         | GRENADIER
     watch           = "tf_microdagr";
 };
 class C_ABG_1 : C_ABG {}; class C_ABG_2 : C_ABG {}; class C_ABG_3 : C_ABG {}; class C_ABG_4 : C_ABG {}; class C_ABG_5 : C_ABG {}; class C_ABG_6 : C_ABG {}; class C_ABG_7 : C_ABG {}; class C_ABG_8 : C_ABG {}; class C_ABG_9 : C_ABG {}; class C_ABG_10 : C_ABG {}; class C_ABG_11 : C_ABG {}; class C_ABG_12 : C_ABG {}; class C_ABG_13 : C_ABG {}; class C_ABG_14 : C_ABG {}; class C_ABG_15 : C_ABG {}; class C_ABG_16 : C_ABG {}; class C_ABG_17 : C_ABG {}; class C_ABG_18 : C_ABG {}; class C_ABG_19 : C_ABG {}; class C_ABG_20 : C_ABG {}; class C_ABG_21 : C_ABG {}; class C_ABG_22 : C_ABG {}; class C_ABG_23 : C_ABG {}; class C_ABG_24 : C_ABG {}; class C_ABG_25 : C_ABG {}; class C_ABG_26 : C_ABG {}; class C_ABG_27 : C_ABG {}; class C_ABG_28 : C_ABG {}; class C_ABG_29 : C_ABG {}; class C_ABG_30 : C_ABG {}; class C_ABG_31 : C_ABG {}; class C_ABG_32 : C_ABG {}; class C_ABG_33 : C_ABG {}; class C_ABG_34 : C_ABG {}; class C_ABG_35 : C_ABG {}; class C_ABG_36 : C_ABG {}; class C_ABG_37 : C_ABG {}; class C_ABG_38 : C_ABG {}; class C_ABG_39 : C_ABG {}; class C_ABG_40 : C_ABG {}; class C_ABG_41 : C_ABG {}; class C_ABG_42 : C_ABG {}; class C_ABG_43 : C_ABG {}; class C_ABG_44 : C_ABG {}; class C_ABG_45 : C_ABG {}; class C_ABG_46 : C_ABG {}; class C_ABG_47 : C_ABG {}; class C_ABG_48 : C_ABG {}; class C_ABG_49 : C_ABG {}; class C_ABG_50 : C_ABG {};
-// ====================================================================================
+
 class C_ABR {                // "R"         | RIFLEMAN
     uniform         = "rhs_uniform_cu_ocp_1stcav";
-    vest            = "rhsusf_iotv_ocp_Grenadier";
+    vest            = "rhsusf_iotv_ocp_Rifleman";
     headgear        = "rhsusf_ach_helmet_camo_ocp";
     goggles         = "rhs_googles_clear";
     nvgoggles       = "rhsusf_ANPVS_14";
@@ -88,7 +88,7 @@ class C_ABR {                // "R"         | RIFLEMAN
     items[] = {};
     magazines[] = {};
     addItemsToUniform[] = {
-        _QUA10(ACE_FieldDressing),
+        _QUA10(ACE_packingBandage),
         _QUA2(ACE_morphine),
         _QUA2(ACE_epinephrine),
         _QUA1(ACE_tourniquet),
@@ -125,7 +125,7 @@ class C_ABR {                // "R"         | RIFLEMAN
     watch           = "tf_microdagr";
 };
 class C_ABR_1 : C_ABR {}; class C_ABR_2 : C_ABR {}; class C_ABR_3 : C_ABR {}; class C_ABR_4 : C_ABR {}; class C_ABR_5 : C_ABR {}; class C_ABR_6 : C_ABR {}; class C_ABR_7 : C_ABR {}; class C_ABR_8 : C_ABR {}; class C_ABR_9 : C_ABR {}; class C_ABR_10 : C_ABR {}; class C_ABR_11 : C_ABR {}; class C_ABR_12 : C_ABR {}; class C_ABR_13 : C_ABR {}; class C_ABR_14 : C_ABR {}; class C_ABR_15 : C_ABR {}; class C_ABR_16 : C_ABR {}; class C_ABR_17 : C_ABR {}; class C_ABR_18 : C_ABR {}; class C_ABR_19 : C_ABR {}; class C_ABR_20 : C_ABR {}; class C_ABR_21 : C_ABR {}; class C_ABR_22 : C_ABR {}; class C_ABR_23 : C_ABR {}; class C_ABR_24 : C_ABR {}; class C_ABR_25 : C_ABR {}; class C_ABR_26 : C_ABR {}; class C_ABR_27 : C_ABR {}; class C_ABR_28 : C_ABR {}; class C_ABR_29 : C_ABR {}; class C_ABR_30 : C_ABR {}; class C_ABR_31 : C_ABR {}; class C_ABR_32 : C_ABR {}; class C_ABR_33 : C_ABR {}; class C_ABR_34 : C_ABR {}; class C_ABR_35 : C_ABR {}; class C_ABR_36 : C_ABR {}; class C_ABR_37 : C_ABR {}; class C_ABR_38 : C_ABR {}; class C_ABR_39 : C_ABR {}; class C_ABR_40 : C_ABR {}; class C_ABR_41 : C_ABR {}; class C_ABR_42 : C_ABR {}; class C_ABR_43 : C_ABR {}; class C_ABR_44 : C_ABR {}; class C_ABR_45 : C_ABR {}; class C_ABR_46 : C_ABR {}; class C_ABR_47 : C_ABR {}; class C_ABR_48 : C_ABR {}; class C_ABR_49 : C_ABR {}; class C_ABR_50 : C_ABR {};
-// ====================================================================================
+
 class C_ABSL {               // "SL"        | SQUAD LEADER
     uniform         = "rhs_uniform_cu_ocp_1stcav";
     vest            = "rhsusf_iotv_ocp_Squadleader";
@@ -146,7 +146,7 @@ class C_ABSL {               // "SL"        | SQUAD LEADER
     items[] = {};
     magazines[] = {};
     addItemsToUniform[] = {
-        _QUA10(ACE_FieldDressing),
+        _QUA10(ACE_packingBandage),
         _QUA2(ACE_morphine),
         _QUA2(ACE_epinephrine),
         _QUA1(ACE_tourniquet),
@@ -191,7 +191,7 @@ class C_ABSL {               // "SL"        | SQUAD LEADER
     watch           = "tf_microdagr";
 };
 class C_ABSL_1 : C_ABSL {}; class C_ABSL_2 : C_ABSL {}; class C_ABSL_3 : C_ABSL {}; class C_ABSL_4 : C_ABSL {}; class C_ABSL_5 : C_ABSL {}; class C_ABSL_6 : C_ABSL {}; class C_ABSL_7 : C_ABSL {}; class C_ABSL_8 : C_ABSL {}; class C_ABSL_9 : C_ABSL {}; class C_ABSL_10 : C_ABSL {}; class C_ABSL_11 : C_ABSL {}; class C_ABSL_12 : C_ABSL {}; class C_ABSL_13 : C_ABSL {}; class C_ABSL_14 : C_ABSL {}; class C_ABSL_15 : C_ABSL {}; class C_ABSL_16 : C_ABSL {}; class C_ABSL_17 : C_ABSL {}; class C_ABSL_18 : C_ABSL {}; class C_ABSL_19 : C_ABSL {}; class C_ABSL_20 : C_ABSL {}; class C_ABSL_21 : C_ABSL {}; class C_ABSL_22 : C_ABSL {}; class C_ABSL_23 : C_ABSL {}; class C_ABSL_24 : C_ABSL {}; class C_ABSL_25 : C_ABSL {}; class C_ABSL_26 : C_ABSL {}; class C_ABSL_27 : C_ABSL {}; class C_ABSL_28 : C_ABSL {}; class C_ABSL_29 : C_ABSL {}; class C_ABSL_30 : C_ABSL {}; class C_ABSL_31 : C_ABSL {}; class C_ABSL_32 : C_ABSL {}; class C_ABSL_33 : C_ABSL {}; class C_ABSL_34 : C_ABSL {}; class C_ABSL_35 : C_ABSL {}; class C_ABSL_36 : C_ABSL {}; class C_ABSL_37 : C_ABSL {}; class C_ABSL_38 : C_ABSL {}; class C_ABSL_39 : C_ABSL {}; class C_ABSL_40 : C_ABSL {}; class C_ABSL_41 : C_ABSL {}; class C_ABSL_42 : C_ABSL {}; class C_ABSL_43 : C_ABSL {}; class C_ABSL_44 : C_ABSL {}; class C_ABSL_45 : C_ABSL {}; class C_ABSL_46 : C_ABSL {}; class C_ABSL_47 : C_ABSL {}; class C_ABSL_48 : C_ABSL {}; class C_ABSL_49 : C_ABSL {}; class C_ABSL_50 : C_ABSL {};
-// ====================================================================================
+
 class C_ABFTL {             // "FTL"       | FIRE TEAM LEADER
     uniform         = "rhs_uniform_cu_ocp_1stcav";
     vest            = "rhsusf_iotv_ocp_Teamleader";
@@ -212,7 +212,7 @@ class C_ABFTL {             // "FTL"       | FIRE TEAM LEADER
     items[] = {};
     magazines[] = {};
     addItemsToUniform[] = {
-        _QUA10(ACE_FieldDressing),
+        _QUA10(ACE_packingBandage),
         _QUA2(ACE_morphine),
         _QUA2(ACE_epinephrine),
         _QUA1(ACE_tourniquet),
@@ -260,7 +260,7 @@ class C_ABFTL {             // "FTL"       | FIRE TEAM LEADER
     watch           = "tf_microdagr";
 };
 class C_ABFTL_1 : C_ABFTL {}; class C_ABFTL_2 : C_ABFTL {}; class C_ABFTL_3 : C_ABFTL {}; class C_ABFTL_4 : C_ABFTL {}; class C_ABFTL_5 : C_ABFTL {}; class C_ABFTL_6 : C_ABFTL {}; class C_ABFTL_7 : C_ABFTL {}; class C_ABFTL_8 : C_ABFTL {}; class C_ABFTL_9 : C_ABFTL {}; class C_ABFTL_10 : C_ABFTL {}; class C_ABFTL_11 : C_ABFTL {}; class C_ABFTL_12 : C_ABFTL {}; class C_ABFTL_13 : C_ABFTL {}; class C_ABFTL_14 : C_ABFTL {}; class C_ABFTL_15 : C_ABFTL {}; class C_ABFTL_16 : C_ABFTL {}; class C_ABFTL_17 : C_ABFTL {}; class C_ABFTL_18 : C_ABFTL {}; class C_ABFTL_19 : C_ABFTL {}; class C_ABFTL_20 : C_ABFTL {}; class C_ABFTL_21 : C_ABFTL {}; class C_ABFTL_22 : C_ABFTL {}; class C_ABFTL_23 : C_ABFTL {}; class C_ABFTL_24 : C_ABFTL {}; class C_ABFTL_25 : C_ABFTL {}; class C_ABFTL_26 : C_ABFTL {}; class C_ABFTL_27 : C_ABFTL {}; class C_ABFTL_28 : C_ABFTL {}; class C_ABFTL_29 : C_ABFTL {}; class C_ABFTL_30 : C_ABFTL {}; class C_ABFTL_31 : C_ABFTL {}; class C_ABFTL_32 : C_ABFTL {}; class C_ABFTL_33 : C_ABFTL {}; class C_ABFTL_34 : C_ABFTL {}; class C_ABFTL_35 : C_ABFTL {}; class C_ABFTL_36 : C_ABFTL {}; class C_ABFTL_37 : C_ABFTL {}; class C_ABFTL_38 : C_ABFTL {}; class C_ABFTL_39 : C_ABFTL {}; class C_ABFTL_40 : C_ABFTL {}; class C_ABFTL_41 : C_ABFTL {}; class C_ABFTL_42 : C_ABFTL {}; class C_ABFTL_43 : C_ABFTL {}; class C_ABFTL_44 : C_ABFTL {}; class C_ABFTL_45 : C_ABFTL {}; class C_ABFTL_46 : C_ABFTL {}; class C_ABFTL_47 : C_ABFTL {}; class C_ABFTL_48 : C_ABFTL {}; class C_ABFTL_49 : C_ABFTL {}; class C_ABFTL_50 : C_ABFTL {};
-// ====================================================================================
+
 class C_ABM {                  // "M"         | COMBAT LIFESAVER
     uniform         = "rhs_uniform_cu_ocp_1stcav";
     vest            = "rhsusf_iotv_ocp_Medic";
@@ -312,8 +312,6 @@ class C_ABM {                  // "M"         | COMBAT LIFESAVER
         _QUA2(Chemlight_Red),	
         _QUA10(ACE_packingBandage),
         _QUA10(ACE_elasticBandage),	
-        _QUA10(ACE_FieldDressing),
-        _QUA10(ACE_quikclot),	
         _QUA2(ACE_salineIV),
         _QUA2(ACE_salineIV_500)				
     };
@@ -325,7 +323,7 @@ class C_ABM {                  // "M"         | COMBAT LIFESAVER
     watch           = "tf_microdagr";
 };
 class C_ABM_1 : C_ABM {}; class C_ABM_2 : C_ABM {}; class C_ABM_3 : C_ABM {}; class C_ABM_4 : C_ABM {}; class C_ABM_5 : C_ABM {}; class C_ABM_6 : C_ABM {}; class C_ABM_7 : C_ABM {}; class C_ABM_8 : C_ABM {}; class C_ABM_9 : C_ABM {}; class C_ABM_10 : C_ABM {}; class C_ABM_11 : C_ABM {}; class C_ABM_12 : C_ABM {}; class C_ABM_13 : C_ABM {}; class C_ABM_14 : C_ABM {}; class C_ABM_15 : C_ABM {}; class C_ABM_16 : C_ABM {}; class C_ABM_17 : C_ABM {}; class C_ABM_18 : C_ABM {}; class C_ABM_19 : C_ABM {}; class C_ABM_20 : C_ABM {}; class C_ABM_21 : C_ABM {}; class C_ABM_22 : C_ABM {}; class C_ABM_23 : C_ABM {}; class C_ABM_24 : C_ABM {}; class C_ABM_25 : C_ABM {}; class C_ABM_26 : C_ABM {}; class C_ABM_27 : C_ABM {}; class C_ABM_28 : C_ABM {}; class C_ABM_29 : C_ABM {}; class C_ABM_30 : C_ABM {}; class C_ABM_31 : C_ABM {}; class C_ABM_32 : C_ABM {}; class C_ABM_33 : C_ABM {}; class C_ABM_34 : C_ABM {}; class C_ABM_35 : C_ABM {}; class C_ABM_36 : C_ABM {}; class C_ABM_37 : C_ABM {}; class C_ABM_38 : C_ABM {}; class C_ABM_39 : C_ABM {}; class C_ABM_40 : C_ABM {}; class C_ABM_41 : C_ABM {}; class C_ABM_42 : C_ABM {}; class C_ABM_43 : C_ABM {}; class C_ABM_44 : C_ABM {}; class C_ABM_45 : C_ABM {}; class C_ABM_46 : C_ABM {}; class C_ABM_47 : C_ABM {}; class C_ABM_48 : C_ABM {}; class C_ABM_49 : C_ABM {}; class C_ABM_50 : C_ABM {};
-// ====================================================================================
+
 class C_ABAR {             // "AR"        | AUTOMATIC RIFLEMAN
     uniform         = "rhs_uniform_cu_ocp_1stcav";
     vest            = "rhsusf_iotv_ocp_SAW";
@@ -346,7 +344,7 @@ class C_ABAR {             // "AR"        | AUTOMATIC RIFLEMAN
     items[] = {};
     magazines[] = {};
     addItemsToUniform[] = {
-        _QUA10(ACE_FieldDressing),
+        _QUA10(ACE_packingBandage),
         _QUA2(ACE_morphine),
         _QUA2(ACE_epinephrine),
         _QUA1(ACE_tourniquet),
@@ -361,20 +359,20 @@ class C_ABAR {             // "AR"        | AUTOMATIC RIFLEMAN
         _QUA1(ACE_DAGR),
         _QUA1(ACE_MapTools),
         _QUA1(ACE_IR_Strobe_Item),
-        _QUA2(_GRENADE)							
+        _QUA2(_GRENADE)
     };
     addItemsToVest[] = {
         _QUA2(_MAG_AR0),
-        _QUA2(_GRENADE),	
-        _QUA4(_GRENADE_SMOKE)							
+        _QUA2(_GRENADE),
+        _QUA4(_GRENADE_SMOKE)
     };
     addItemsToBackpack[] = {
         _QUA2(_MAG_AR0),
         _QUA2(rhsusf_mag_15Rnd_9x19_JHP),
-        _QUA2(_GRENADE),	
-        _QUA4(_GRENADE_SMOKE),	
+        _QUA2(_GRENADE),
+        _QUA4(_GRENADE_SMOKE),
         _QUA2(Chemlight_Blue),
-        _QUA2(Chemlight_Red)						
+        _QUA2(Chemlight_Red)
     };
     
     binoculars      = "";
@@ -384,10 +382,10 @@ class C_ABAR {             // "AR"        | AUTOMATIC RIFLEMAN
     watch           = "tf_microdagr";
 };
 class C_ABAR_1 : C_ABAR {}; class C_ABAR_2 : C_ABAR {}; class C_ABAR_3 : C_ABAR {}; class C_ABAR_4 : C_ABAR {}; class C_ABAR_5 : C_ABAR {}; class C_ABAR_6 : C_ABAR {}; class C_ABAR_7 : C_ABAR {}; class C_ABAR_8 : C_ABAR {}; class C_ABAR_9 : C_ABAR {}; class C_ABAR_10 : C_ABAR {}; class C_ABAR_11 : C_ABAR {}; class C_ABAR_12 : C_ABAR {}; class C_ABAR_13 : C_ABAR {}; class C_ABAR_14 : C_ABAR {}; class C_ABAR_15 : C_ABAR {}; class C_ABAR_16 : C_ABAR {}; class C_ABAR_17 : C_ABAR {}; class C_ABAR_18 : C_ABAR {}; class C_ABAR_19 : C_ABAR {}; class C_ABAR_20 : C_ABAR {}; class C_ABAR_21 : C_ABAR {}; class C_ABAR_22 : C_ABAR {}; class C_ABAR_23 : C_ABAR {}; class C_ABAR_24 : C_ABAR {}; class C_ABAR_25 : C_ABAR {}; class C_ABAR_26 : C_ABAR {}; class C_ABAR_27 : C_ABAR {}; class C_ABAR_28 : C_ABAR {}; class C_ABAR_29 : C_ABAR {}; class C_ABAR_30 : C_ABAR {}; class C_ABAR_31 : C_ABAR {}; class C_ABAR_32 : C_ABAR {}; class C_ABAR_33 : C_ABAR {}; class C_ABAR_34 : C_ABAR {}; class C_ABAR_35 : C_ABAR {}; class C_ABAR_36 : C_ABAR {}; class C_ABAR_37 : C_ABAR {}; class C_ABAR_38 : C_ABAR {}; class C_ABAR_39 : C_ABAR {}; class C_ABAR_40 : C_ABAR {}; class C_ABAR_41 : C_ABAR {}; class C_ABAR_42 : C_ABAR {}; class C_ABAR_43 : C_ABAR {}; class C_ABAR_44 : C_ABAR {}; class C_ABAR_45 : C_ABAR {}; class C_ABAR_46 : C_ABAR {}; class C_ABAR_47 : C_ABAR {}; class C_ABAR_48 : C_ABAR {}; class C_ABAR_49 : C_ABAR {}; class C_ABAR_50 : C_ABAR {};
-// ====================================================================================
+
 class C_ABAA {             // "AA"        | ANTI-AIR
     uniform         = "rhs_uniform_cu_ocp_1stcav";
-    vest            = "rhsusf_iotv_ocp_Grenadier";
+    vest            = "rhsusf_iotv_ocp_Rifleman";
     headgear        = "rhsusf_ach_helmet_camo_ocp";
     goggles         = "rhs_googles_clear";
     nvgoggles       = "rhsusf_ANPVS_14";
@@ -405,7 +403,7 @@ class C_ABAA {             // "AA"        | ANTI-AIR
     items[] = {};
     magazines[] = {};
     addItemsToUniform[] = {
-        _QUA10(ACE_FieldDressing),
+        _QUA10(ACE_packingBandage),
         _QUA2(ACE_morphine),
         _QUA2(ACE_epinephrine),
         _QUA1(ACE_tourniquet),
@@ -420,20 +418,20 @@ class C_ABAA {             // "AA"        | ANTI-AIR
         _QUA1(ACE_DAGR),
         _QUA1(ACE_MapTools),
         _QUA1(ACE_IR_Strobe_Item),
-        _QUA2(_GRENADE)							
+        _QUA2(_GRENADE)
     };
     addItemsToVest[] = {
         _QUA6(_MAG_PRIMARY),
         _QUA2(_GRENADE),	
-        _QUA4(_GRENADE_SMOKE)							
+        _QUA4(_GRENADE_SMOKE)
     };
     addItemsToBackpack[] = {
         _QUA2(_MAG_PRIMARY),
-        _QUA2(_GRENADE),	
-        _QUA4(_GRENADE_SMOKE),	
+        _QUA2(_GRENADE),
+        _QUA4(_GRENADE_SMOKE),
         _QUA2(Chemlight_Blue),
         _QUA2(Chemlight_Red),
-        _QUA1(_MAG_LAUNCHER1)						
+        _QUA1(_MAG_LAUNCHER1)
     };
     
     binoculars      = "";
@@ -443,10 +441,10 @@ class C_ABAA {             // "AA"        | ANTI-AIR
     watch           = "tf_microdagr";
 };
 class C_ABAA_1 : C_ABAA {}; class C_ABAA_2 : C_ABAA {}; class C_ABAA_3 : C_ABAA {}; class C_ABAA_4 : C_ABAA {}; class C_ABAA_5 : C_ABAA {}; class C_ABAA_6 : C_ABAA {}; class C_ABAA_7 : C_ABAA {}; class C_ABAA_8 : C_ABAA {}; class C_ABAA_9 : C_ABAA {}; class C_ABAA_10 : C_ABAA {}; class C_ABAA_11 : C_ABAA {}; class C_ABAA_12 : C_ABAA {}; class C_ABAA_13 : C_ABAA {}; class C_ABAA_14 : C_ABAA {}; class C_ABAA_15 : C_ABAA {}; class C_ABAA_16 : C_ABAA {}; class C_ABAA_17 : C_ABAA {}; class C_ABAA_18 : C_ABAA {}; class C_ABAA_19 : C_ABAA {}; class C_ABAA_20 : C_ABAA {}; class C_ABAA_21 : C_ABAA {}; class C_ABAA_22 : C_ABAA {}; class C_ABAA_23 : C_ABAA {}; class C_ABAA_24 : C_ABAA {}; class C_ABAA_25 : C_ABAA {}; class C_ABAA_26 : C_ABAA {}; class C_ABAA_27 : C_ABAA {}; class C_ABAA_28 : C_ABAA {}; class C_ABAA_29 : C_ABAA {}; class C_ABAA_30 : C_ABAA {}; class C_ABAA_31 : C_ABAA {}; class C_ABAA_32 : C_ABAA {}; class C_ABAA_33 : C_ABAA {}; class C_ABAA_34 : C_ABAA {}; class C_ABAA_35 : C_ABAA {}; class C_ABAA_36 : C_ABAA {}; class C_ABAA_37 : C_ABAA {}; class C_ABAA_38 : C_ABAA {}; class C_ABAA_39 : C_ABAA {}; class C_ABAA_40 : C_ABAA {}; class C_ABAA_41 : C_ABAA {}; class C_ABAA_42 : C_ABAA {}; class C_ABAA_43 : C_ABAA {}; class C_ABAA_44 : C_ABAA {}; class C_ABAA_45 : C_ABAA {}; class C_ABAA_46 : C_ABAA {}; class C_ABAA_47 : C_ABAA {}; class C_ABAA_48 : C_ABAA {}; class C_ABAA_49 : C_ABAA {}; class C_ABAA_50 : C_ABAA {};
-// ====================================================================================
+
 class C_ABENG {               // "ENG"       | ENGINEER
     uniform         = "rhs_uniform_cu_ocp_1stcav";
-    vest            = "rhsusf_iotv_ocp_SAW";
+    vest            = "rhsusf_iotv_ocp_Repair";
     headgear        = "rhsusf_ach_helmet_camo_ocp";
     goggles         = "rhs_ess_black";
     nvgoggles       = "rhsusf_ANPVS_14";
@@ -464,7 +462,7 @@ class C_ABENG {               // "ENG"       | ENGINEER
     items[] = {};
     magazines[] = {};
     addItemsToUniform[] = {
-        _QUA10(ACE_FieldDressing),
+        _QUA10(ACE_packingBandage),
         _QUA2(ACE_morphine),
         _QUA2(ACE_epinephrine),
         _QUA1(ACE_tourniquet),
@@ -479,7 +477,7 @@ class C_ABENG {               // "ENG"       | ENGINEER
         _QUA1(ACE_DAGR),
         _QUA1(ACE_MapTools),
         _QUA1(ACE_IR_Strobe_Item),
-        _QUA2(_GRENADE)							
+        _QUA2(_GRENADE)
     };
     addItemsToVest[] = {
         _QUA4(_MAG_PRIMARY),
@@ -502,7 +500,7 @@ class C_ABENG {               // "ENG"       | ENGINEER
     watch           = "tf_microdagr";
 };
 class C_ABENG_1 : C_ABENG {}; class C_ABENG_2 : C_ABENG {}; class C_ABENG_3 : C_ABENG {}; class C_ABENG_4 : C_ABENG {}; class C_ABENG_5 : C_ABENG {}; class C_ABENG_6 : C_ABENG {}; class C_ABENG_7 : C_ABENG {}; class C_ABENG_8 : C_ABENG {}; class C_ABENG_9 : C_ABENG {}; class C_ABENG_10 : C_ABENG {}; class C_ABENG_11 : C_ABENG {}; class C_ABENG_12 : C_ABENG {}; class C_ABENG_13 : C_ABENG {}; class C_ABENG_14 : C_ABENG {}; class C_ABENG_15 : C_ABENG {}; class C_ABENG_16 : C_ABENG {}; class C_ABENG_17 : C_ABENG {}; class C_ABENG_18 : C_ABENG {}; class C_ABENG_19 : C_ABENG {}; class C_ABENG_20 : C_ABENG {}; class C_ABENG_21 : C_ABENG {}; class C_ABENG_22 : C_ABENG {}; class C_ABENG_23 : C_ABENG {}; class C_ABENG_24 : C_ABENG {}; class C_ABENG_25 : C_ABENG {}; class C_ABENG_26 : C_ABENG {}; class C_ABENG_27 : C_ABENG {}; class C_ABENG_28 : C_ABENG {}; class C_ABENG_29 : C_ABENG {}; class C_ABENG_30 : C_ABENG {}; class C_ABENG_31 : C_ABENG {}; class C_ABENG_32 : C_ABENG {}; class C_ABENG_33 : C_ABENG {}; class C_ABENG_34 : C_ABENG {}; class C_ABENG_35 : C_ABENG {}; class C_ABENG_36 : C_ABENG {}; class C_ABENG_37 : C_ABENG {}; class C_ABENG_38 : C_ABENG {}; class C_ABENG_39 : C_ABENG {}; class C_ABENG_40 : C_ABENG {}; class C_ABENG_41 : C_ABENG {}; class C_ABENG_42 : C_ABENG {}; class C_ABENG_43 : C_ABENG {}; class C_ABENG_44 : C_ABENG {}; class C_ABENG_45 : C_ABENG {}; class C_ABENG_46 : C_ABENG {}; class C_ABENG_47 : C_ABENG {}; class C_ABENG_48 : C_ABENG {}; class C_ABENG_49 : C_ABENG {}; class C_ABENG_50 : C_ABENG {};
-// ====================================================================================
+
 class C_ABAR2 {            // "AR2"       | AUTOMATIC RIFLEMAN 2
     uniform         = "rhs_uniform_cu_ocp_1stcav";
     vest            = "rhsusf_iotv_ocp_SAW";
@@ -523,7 +521,7 @@ class C_ABAR2 {            // "AR2"       | AUTOMATIC RIFLEMAN 2
     items[] = {};
     magazines[] = {};
     addItemsToUniform[] = {
-        _QUA10(ACE_FieldDressing),
+        _QUA10(ACE_packingBandage),
         _QUA2(ACE_morphine),
         _QUA2(ACE_epinephrine),
         _QUA1(ACE_tourniquet),
@@ -561,10 +559,10 @@ class C_ABAR2 {            // "AR2"       | AUTOMATIC RIFLEMAN 2
     watch           = "tf_microdagr";
 };
 class C_ABAR2_1 : C_ABAR2 {}; class C_ABAR2_2 : C_ABAR2 {}; class C_ABAR2_3 : C_ABAR2 {}; class C_ABAR2_4 : C_ABAR2 {}; class C_ABAR2_5 : C_ABAR2 {}; class C_ABAR2_6 : C_ABAR2 {}; class C_ABAR2_7 : C_ABAR2 {}; class C_ABAR2_8 : C_ABAR2 {}; class C_ABAR2_9 : C_ABAR2 {}; class C_ABAR2_10 : C_ABAR2 {}; class C_ABAR2_11 : C_ABAR2 {}; class C_ABAR2_12 : C_ABAR2 {}; class C_ABAR2_13 : C_ABAR2 {}; class C_ABAR2_14 : C_ABAR2 {}; class C_ABAR2_15 : C_ABAR2 {}; class C_ABAR2_16 : C_ABAR2 {}; class C_ABAR2_17 : C_ABAR2 {}; class C_ABAR2_18 : C_ABAR2 {}; class C_ABAR2_19 : C_ABAR2 {}; class C_ABAR2_20 : C_ABAR2 {}; class C_ABAR2_21 : C_ABAR2 {}; class C_ABAR2_22 : C_ABAR2 {}; class C_ABAR2_23 : C_ABAR2 {}; class C_ABAR2_24 : C_ABAR2 {}; class C_ABAR2_25 : C_ABAR2 {}; class C_ABAR2_26 : C_ABAR2 {}; class C_ABAR2_27 : C_ABAR2 {}; class C_ABAR2_28 : C_ABAR2 {}; class C_ABAR2_29 : C_ABAR2 {}; class C_ABAR2_30 : C_ABAR2 {}; class C_ABAR2_31 : C_ABAR2 {}; class C_ABAR2_32 : C_ABAR2 {}; class C_ABAR2_33 : C_ABAR2 {}; class C_ABAR2_34 : C_ABAR2 {}; class C_ABAR2_35 : C_ABAR2 {}; class C_ABAR2_36 : C_ABAR2 {}; class C_ABAR2_37 : C_ABAR2 {}; class C_ABAR2_38 : C_ABAR2 {}; class C_ABAR2_39 : C_ABAR2 {}; class C_ABAR2_40 : C_ABAR2 {}; class C_ABAR2_41 : C_ABAR2 {}; class C_ABAR2_42 : C_ABAR2 {}; class C_ABAR2_43 : C_ABAR2 {}; class C_ABAR2_44 : C_ABAR2 {}; class C_ABAR2_45 : C_ABAR2 {}; class C_ABAR2_46 : C_ABAR2 {}; class C_ABAR2_47 : C_ABAR2 {}; class C_ABAR2_48 : C_ABAR2 {}; class C_ABAR2_49 : C_ABAR2 {}; class C_ABAR2_50 : C_ABAR2 {};
-// ====================================================================================
+
 class C_ABATL {            // "ATL"       | LIGHT ANTI-TANK
     uniform         = "rhs_uniform_cu_ocp_1stcav";
-    vest            = "rhsusf_iotv_ocp_Grenadier";
+    vest            = "rhsusf_iotv_ocp_Rifleman";
     headgear        = "rhsusf_ach_helmet_camo_ocp";
     goggles         = "rhs_googles_clear";
     nvgoggles       = "rhsusf_ANPVS_14";
@@ -582,7 +580,7 @@ class C_ABATL {            // "ATL"       | LIGHT ANTI-TANK
     items[] = {};
     magazines[] = {};
     addItemsToUniform[] = {
-        _QUA10(ACE_FieldDressing),
+        _QUA10(ACE_packingBandage),
         _QUA2(ACE_morphine),
         _QUA2(ACE_epinephrine),
         _QUA1(ACE_tourniquet),
@@ -619,7 +617,7 @@ class C_ABATL {            // "ATL"       | LIGHT ANTI-TANK
     watch           = "tf_microdagr";
 };
 class C_ABATL_1 : C_ABATL {}; class C_ABATL_2 : C_ABATL {}; class C_ABATL_3 : C_ABATL {}; class C_ABATL_4 : C_ABATL {}; class C_ABATL_5 : C_ABATL {}; class C_ABATL_6 : C_ABATL {}; class C_ABATL_7 : C_ABATL {}; class C_ABATL_8 : C_ABATL {}; class C_ABATL_9 : C_ABATL {}; class C_ABATL_10 : C_ABATL {}; class C_ABATL_11 : C_ABATL {}; class C_ABATL_12 : C_ABATL {}; class C_ABATL_13 : C_ABATL {}; class C_ABATL_14 : C_ABATL {}; class C_ABATL_15 : C_ABATL {}; class C_ABATL_16 : C_ABATL {}; class C_ABATL_17 : C_ABATL {}; class C_ABATL_18 : C_ABATL {}; class C_ABATL_19 : C_ABATL {}; class C_ABATL_20 : C_ABATL {}; class C_ABATL_21 : C_ABATL {}; class C_ABATL_22 : C_ABATL {}; class C_ABATL_23 : C_ABATL {}; class C_ABATL_24 : C_ABATL {}; class C_ABATL_25 : C_ABATL {}; class C_ABATL_26 : C_ABATL {}; class C_ABATL_27 : C_ABATL {}; class C_ABATL_28 : C_ABATL {}; class C_ABATL_29 : C_ABATL {}; class C_ABATL_30 : C_ABATL {}; class C_ABATL_31 : C_ABATL {}; class C_ABATL_32 : C_ABATL {}; class C_ABATL_33 : C_ABATL {}; class C_ABATL_34 : C_ABATL {}; class C_ABATL_35 : C_ABATL {}; class C_ABATL_36 : C_ABATL {}; class C_ABATL_37 : C_ABATL {}; class C_ABATL_38 : C_ABATL {}; class C_ABATL_39 : C_ABATL {}; class C_ABATL_40 : C_ABATL {}; class C_ABATL_41 : C_ABATL {}; class C_ABATL_42 : C_ABATL {}; class C_ABATL_43 : C_ABATL {}; class C_ABATL_44 : C_ABATL {}; class C_ABATL_45 : C_ABATL {}; class C_ABATL_46 : C_ABATL {}; class C_ABATL_47 : C_ABATL {}; class C_ABATL_48 : C_ABATL {}; class C_ABATL_49 : C_ABATL {}; class C_ABATL_50 : C_ABATL {};
-// ====================================================================================
+
 class C_ABJTAC {             // "JTAC"      | JTAC
     uniform         = "rhs_uniform_cu_ocp_1stcav";
     vest            = "rhsusf_iotv_ocp_Squadleader";
@@ -640,7 +638,7 @@ class C_ABJTAC {             // "JTAC"      | JTAC
     items[] = {};
     magazines[] = {};
     addItemsToUniform[] = {
-        _QUA10(ACE_FieldDressing),
+        _QUA10(ACE_packingBandage),
         _QUA2(ACE_morphine),
         _QUA2(ACE_epinephrine),
         _QUA1(ACE_tourniquet),
@@ -686,7 +684,7 @@ class C_ABJTAC {             // "JTAC"      | JTAC
     watch           = "tf_microdagr";
 };
 class C_ABJTAC_1 : C_ABJTAC {}; class C_ABJTAC_2 : C_ABJTAC {}; class C_ABJTAC_3 : C_ABJTAC {}; class C_ABJTAC_4 : C_ABJTAC {}; class C_ABJTAC_5 : C_ABJTAC {}; class C_ABJTAC_6 : C_ABJTAC {}; class C_ABJTAC_7 : C_ABJTAC {}; class C_ABJTAC_8 : C_ABJTAC {}; class C_ABJTAC_9 : C_ABJTAC {}; class C_ABJTAC_10 : C_ABJTAC {}; class C_ABJTAC_11 : C_ABJTAC {}; class C_ABJTAC_12 : C_ABJTAC {}; class C_ABJTAC_13 : C_ABJTAC {}; class C_ABJTAC_14 : C_ABJTAC {}; class C_ABJTAC_15 : C_ABJTAC {}; class C_ABJTAC_16 : C_ABJTAC {}; class C_ABJTAC_17 : C_ABJTAC {}; class C_ABJTAC_18 : C_ABJTAC {}; class C_ABJTAC_19 : C_ABJTAC {}; class C_ABJTAC_20 : C_ABJTAC {}; class C_ABJTAC_21 : C_ABJTAC {}; class C_ABJTAC_22 : C_ABJTAC {}; class C_ABJTAC_23 : C_ABJTAC {}; class C_ABJTAC_24 : C_ABJTAC {}; class C_ABJTAC_25 : C_ABJTAC {}; class C_ABJTAC_26 : C_ABJTAC {}; class C_ABJTAC_27 : C_ABJTAC {}; class C_ABJTAC_28 : C_ABJTAC {}; class C_ABJTAC_29 : C_ABJTAC {}; class C_ABJTAC_30 : C_ABJTAC {}; class C_ABJTAC_31 : C_ABJTAC {}; class C_ABJTAC_32 : C_ABJTAC {}; class C_ABJTAC_33 : C_ABJTAC {}; class C_ABJTAC_34 : C_ABJTAC {}; class C_ABJTAC_35 : C_ABJTAC {}; class C_ABJTAC_36 : C_ABJTAC {}; class C_ABJTAC_37 : C_ABJTAC {}; class C_ABJTAC_38 : C_ABJTAC {}; class C_ABJTAC_39 : C_ABJTAC {}; class C_ABJTAC_40 : C_ABJTAC {}; class C_ABJTAC_41 : C_ABJTAC {}; class C_ABJTAC_42 : C_ABJTAC {}; class C_ABJTAC_43 : C_ABJTAC {}; class C_ABJTAC_44 : C_ABJTAC {}; class C_ABJTAC_45 : C_ABJTAC {}; class C_ABJTAC_46 : C_ABJTAC {}; class C_ABJTAC_47 : C_ABJTAC {}; class C_ABJTAC_48 : C_ABJTAC {}; class C_ABJTAC_49 : C_ABJTAC {}; class C_ABJTAC_50 : C_ABJTAC {};
-// ====================================================================================
+
 class C_ABFO {           // "FO"        | FORWARD OBSERVER
     uniform         = "rhs_uniform_cu_ocp_1stcav";
     vest            = "rhsusf_iotv_ocp_Squadleader";
@@ -707,7 +705,7 @@ class C_ABFO {           // "FO"        | FORWARD OBSERVER
     items[] = {};
     magazines[] = {};
     addItemsToUniform[] = {
-        _QUA10(ACE_FieldDressing),
+        _QUA10(ACE_packingBandage),
         _QUA2(ACE_morphine),
         _QUA2(ACE_epinephrine),
         _QUA1(ACE_tourniquet),
@@ -752,10 +750,10 @@ class C_ABFO {           // "FO"        | FORWARD OBSERVER
     watch           = "tf_microdagr";
 };
 class C_ABFO_1 : C_ABFO {}; class C_ABFO_2 : C_ABFO {}; class C_ABFO_3 : C_ABFO {}; class C_ABFO_4 : C_ABFO {}; class C_ABFO_5 : C_ABFO {}; class C_ABFO_6 : C_ABFO {}; class C_ABFO_7 : C_ABFO {}; class C_ABFO_8 : C_ABFO {}; class C_ABFO_9 : C_ABFO {}; class C_ABFO_10 : C_ABFO {}; class C_ABFO_11 : C_ABFO {}; class C_ABFO_12 : C_ABFO {}; class C_ABFO_13 : C_ABFO {}; class C_ABFO_14 : C_ABFO {}; class C_ABFO_15 : C_ABFO {}; class C_ABFO_16 : C_ABFO {}; class C_ABFO_17 : C_ABFO {}; class C_ABFO_18 : C_ABFO {}; class C_ABFO_19 : C_ABFO {}; class C_ABFO_20 : C_ABFO {}; class C_ABFO_21 : C_ABFO {}; class C_ABFO_22 : C_ABFO {}; class C_ABFO_23 : C_ABFO {}; class C_ABFO_24 : C_ABFO {}; class C_ABFO_25 : C_ABFO {}; class C_ABFO_26 : C_ABFO {}; class C_ABFO_27 : C_ABFO {}; class C_ABFO_28 : C_ABFO {}; class C_ABFO_29 : C_ABFO {}; class C_ABFO_30 : C_ABFO {}; class C_ABFO_31 : C_ABFO {}; class C_ABFO_32 : C_ABFO {}; class C_ABFO_33 : C_ABFO {}; class C_ABFO_34 : C_ABFO {}; class C_ABFO_35 : C_ABFO {}; class C_ABFO_36 : C_ABFO {}; class C_ABFO_37 : C_ABFO {}; class C_ABFO_38 : C_ABFO {}; class C_ABFO_39 : C_ABFO {}; class C_ABFO_40 : C_ABFO {}; class C_ABFO_41 : C_ABFO {}; class C_ABFO_42 : C_ABFO {}; class C_ABFO_43 : C_ABFO {}; class C_ABFO_44 : C_ABFO {}; class C_ABFO_45 : C_ABFO {}; class C_ABFO_46 : C_ABFO {}; class C_ABFO_47 : C_ABFO {}; class C_ABFO_48 : C_ABFO {}; class C_ABFO_49 : C_ABFO {}; class C_ABFO_50 : C_ABFO {};
-// ====================================================================================
+
 class C_ABENGSL {         // "ENGSL"     | ENGINEER SL
     uniform         = "rhs_uniform_cu_ocp_1stcav";
-    vest            = "rhsusf_iotv_ocp_SAW";
+    vest            = "rhsusf_iotv_ocp_Repair";
     headgear        = "rhsusf_ach_helmet_camo_ocp";
     goggles         = "rhs_ess_black";
     nvgoggles       = "rhsusf_ANPVS_14";
@@ -773,7 +771,7 @@ class C_ABENGSL {         // "ENGSL"     | ENGINEER SL
     items[] = {};
     magazines[] = {};
     addItemsToUniform[] = {
-        _QUA10(ACE_FieldDressing),
+        _QUA10(ACE_packingBandage),
         _QUA2(ACE_morphine),
         _QUA2(ACE_epinephrine),
         _QUA1(ACE_tourniquet),
@@ -811,7 +809,7 @@ class C_ABENGSL {         // "ENGSL"     | ENGINEER SL
     watch           = "tf_microdagr";
 };
 class C_ABENGSL_1 : C_ABENGSL {}; class C_ABENGSL_2 : C_ABENGSL {}; class C_ABENGSL_3 : C_ABENGSL {}; class C_ABENGSL_4 : C_ABENGSL {}; class C_ABENGSL_5 : C_ABENGSL {}; class C_ABENGSL_6 : C_ABENGSL {}; class C_ABENGSL_7 : C_ABENGSL {}; class C_ABENGSL_8 : C_ABENGSL {}; class C_ABENGSL_9 : C_ABENGSL {}; class C_ABENGSL_10 : C_ABENGSL {}; class C_ABENGSL_11 : C_ABENGSL {}; class C_ABENGSL_12 : C_ABENGSL {}; class C_ABENGSL_13 : C_ABENGSL {}; class C_ABENGSL_14 : C_ABENGSL {}; class C_ABENGSL_15 : C_ABENGSL {}; class C_ABENGSL_16 : C_ABENGSL {}; class C_ABENGSL_17 : C_ABENGSL {}; class C_ABENGSL_18 : C_ABENGSL {}; class C_ABENGSL_19 : C_ABENGSL {}; class C_ABENGSL_20 : C_ABENGSL {}; class C_ABENGSL_21 : C_ABENGSL {}; class C_ABENGSL_22 : C_ABENGSL {}; class C_ABENGSL_23 : C_ABENGSL {}; class C_ABENGSL_24 : C_ABENGSL {}; class C_ABENGSL_25 : C_ABENGSL {}; class C_ABENGSL_26 : C_ABENGSL {}; class C_ABENGSL_27 : C_ABENGSL {}; class C_ABENGSL_28 : C_ABENGSL {}; class C_ABENGSL_29 : C_ABENGSL {}; class C_ABENGSL_30 : C_ABENGSL {}; class C_ABENGSL_31 : C_ABENGSL {}; class C_ABENGSL_32 : C_ABENGSL {}; class C_ABENGSL_33 : C_ABENGSL {}; class C_ABENGSL_34 : C_ABENGSL {}; class C_ABENGSL_35 : C_ABENGSL {}; class C_ABENGSL_36 : C_ABENGSL {}; class C_ABENGSL_37 : C_ABENGSL {}; class C_ABENGSL_38 : C_ABENGSL {}; class C_ABENGSL_39 : C_ABENGSL {}; class C_ABENGSL_40 : C_ABENGSL {}; class C_ABENGSL_41 : C_ABENGSL {}; class C_ABENGSL_42 : C_ABENGSL {}; class C_ABENGSL_43 : C_ABENGSL {}; class C_ABENGSL_44 : C_ABENGSL {}; class C_ABENGSL_45 : C_ABENGSL {}; class C_ABENGSL_46 : C_ABENGSL {}; class C_ABENGSL_47 : C_ABENGSL {}; class C_ABENGSL_48 : C_ABENGSL {}; class C_ABENGSL_49 : C_ABENGSL {}; class C_ABENGSL_50 : C_ABENGSL {};
-// ====================================================================================
+
 class C_ABOFF {                // "OFF"       | OFFICER
     uniform         = "rhs_uniform_cu_ocp_1stcav";
     vest            = "rhsusf_iotv_ocp_Squadleader";
@@ -832,7 +830,7 @@ class C_ABOFF {                // "OFF"       | OFFICER
     items[] = {};
     magazines[] = {};
     addItemsToUniform[] = {
-        _QUA10(ACE_FieldDressing),
+        _QUA10(ACE_packingBandage),
         _QUA2(ACE_morphine),
         _QUA2(ACE_epinephrine),
         _QUA1(ACE_tourniquet),
@@ -877,4 +875,4 @@ class C_ABOFF {                // "OFF"       | OFFICER
     watch           = "tf_microdagr";
 };
 class C_ABOFF_1 : C_ABOFF {}; class C_ABOFF_2 : C_ABOFF {}; class C_ABOFF_3 : C_ABOFF {}; class C_ABOFF_4 : C_ABOFF {}; class C_ABOFF_5 : C_ABOFF {}; class C_ABOFF_6 : C_ABOFF {}; class C_ABOFF_7 : C_ABOFF {}; class C_ABOFF_8 : C_ABOFF {}; class C_ABOFF_9 : C_ABOFF {}; class C_ABOFF_10 : C_ABOFF {}; class C_ABOFF_11 : C_ABOFF {}; class C_ABOFF_12 : C_ABOFF {}; class C_ABOFF_13 : C_ABOFF {}; class C_ABOFF_14 : C_ABOFF {}; class C_ABOFF_15 : C_ABOFF {}; class C_ABOFF_16 : C_ABOFF {}; class C_ABOFF_17 : C_ABOFF {}; class C_ABOFF_18 : C_ABOFF {}; class C_ABOFF_19 : C_ABOFF {}; class C_ABOFF_20 : C_ABOFF {}; class C_ABOFF_21 : C_ABOFF {}; class C_ABOFF_22 : C_ABOFF {}; class C_ABOFF_23 : C_ABOFF {}; class C_ABOFF_24 : C_ABOFF {}; class C_ABOFF_25 : C_ABOFF {}; class C_ABOFF_26 : C_ABOFF {}; class C_ABOFF_27 : C_ABOFF {}; class C_ABOFF_28 : C_ABOFF {}; class C_ABOFF_29 : C_ABOFF {}; class C_ABOFF_30 : C_ABOFF {}; class C_ABOFF_31 : C_ABOFF {}; class C_ABOFF_32 : C_ABOFF {}; class C_ABOFF_33 : C_ABOFF {}; class C_ABOFF_34 : C_ABOFF {}; class C_ABOFF_35 : C_ABOFF {}; class C_ABOFF_36 : C_ABOFF {}; class C_ABOFF_37 : C_ABOFF {}; class C_ABOFF_38 : C_ABOFF {}; class C_ABOFF_39 : C_ABOFF {}; class C_ABOFF_40 : C_ABOFF {}; class C_ABOFF_41 : C_ABOFF {}; class C_ABOFF_42 : C_ABOFF {}; class C_ABOFF_43 : C_ABOFF {}; class C_ABOFF_44 : C_ABOFF {}; class C_ABOFF_45 : C_ABOFF {}; class C_ABOFF_46 : C_ABOFF {}; class C_ABOFF_47 : C_ABOFF {}; class C_ABOFF_48 : C_ABOFF {}; class C_ABOFF_49 : C_ABOFF {}; class C_ABOFF_50 : C_ABOFF {};
-// ====================================================================================		
+		

--- a/cScripts/Loadouts/loadout_Common.hpp
+++ b/cScripts/Loadouts/loadout_Common.hpp
@@ -1,5 +1,5 @@
 /*
-GearVersionDate: 160303
+GearVersionDate: 160413
 */
 class C_G {                // "G"         | GRENADIER
     uniform         = "rhs_uniform_cu_ocp_1stcav";
@@ -21,7 +21,7 @@ class C_G {                // "G"         | GRENADIER
     items[] = {};
     magazines[] = {};
     addItemsToUniform[] = {
-        _QUA10(ACE_FieldDressing),
+        _QUA10(ACE_packingBandage),
         _QUA2(ACE_morphine),
         _QUA2(ACE_epinephrine),
         _QUA1(ACE_tourniquet),
@@ -67,7 +67,7 @@ class C_G {                // "G"         | GRENADIER
     watch           = "tf_microdagr";
 };
 class C_G_1 : C_G {}; class C_G_2 : C_G {}; class C_G_3 : C_G {}; class C_G_4 : C_G {}; class C_G_5 : C_G {}; class C_G_6 : C_G {}; class C_G_7 : C_G {}; class C_G_8 : C_G {}; class C_G_9 : C_G {}; class C_G_10 : C_G {}; class C_G_11 : C_G {}; class C_G_12 : C_G {}; class C_G_13 : C_G {}; class C_G_14 : C_G {}; class C_G_15 : C_G {}; class C_G_16 : C_G {}; class C_G_17 : C_G {}; class C_G_18 : C_G {}; class C_G_19 : C_G {}; class C_G_20 : C_G {}; class C_G_21 : C_G {}; class C_G_22 : C_G {}; class C_G_23 : C_G {}; class C_G_24 : C_G {}; class C_G_25 : C_G {}; class C_G_26 : C_G {}; class C_G_27 : C_G {}; class C_G_28 : C_G {}; class C_G_29 : C_G {}; class C_G_30 : C_G {}; class C_G_31 : C_G {}; class C_G_32 : C_G {}; class C_G_33 : C_G {}; class C_G_34 : C_G {}; class C_G_35 : C_G {}; class C_G_36 : C_G {}; class C_G_37 : C_G {}; class C_G_38 : C_G {}; class C_G_39 : C_G {}; class C_G_40 : C_G {}; class C_G_41 : C_G {}; class C_G_42 : C_G {}; class C_G_43 : C_G {}; class C_G_44 : C_G {}; class C_G_45 : C_G {}; class C_G_46 : C_G {}; class C_G_47 : C_G {}; class C_G_48 : C_G {}; class C_G_49 : C_G {}; class C_G_50 : C_G {};
-// ====================================================================================
+
 class C_R {                // "R"         | RIFLEMAN
     uniform         = "rhs_uniform_cu_ocp_1stcav";
     vest            = "rhsusf_iotv_ocp_Rifleman";
@@ -88,7 +88,7 @@ class C_R {                // "R"         | RIFLEMAN
     items[] = {};
     magazines[] = {};
     addItemsToUniform[] = {
-        _QUA10(ACE_FieldDressing),
+        _QUA10(ACE_packingBandage),
         _QUA2(ACE_morphine),
         _QUA2(ACE_epinephrine),
         _QUA1(ACE_tourniquet),
@@ -125,66 +125,7 @@ class C_R {                // "R"         | RIFLEMAN
     watch           = "tf_microdagr";
 };
 class C_R_1 : C_R {}; class C_R_2 : C_R {}; class C_R_3 : C_R {}; class C_R_4 : C_R {}; class C_R_5 : C_R {}; class C_R_6 : C_R {}; class C_R_7 : C_R {}; class C_R_8 : C_R {}; class C_R_9 : C_R {}; class C_R_10 : C_R {}; class C_R_11 : C_R {}; class C_R_12 : C_R {}; class C_R_13 : C_R {}; class C_R_14 : C_R {}; class C_R_15 : C_R {}; class C_R_16 : C_R {}; class C_R_17 : C_R {}; class C_R_18 : C_R {}; class C_R_19 : C_R {}; class C_R_20 : C_R {}; class C_R_21 : C_R {}; class C_R_22 : C_R {}; class C_R_23 : C_R {}; class C_R_24 : C_R {}; class C_R_25 : C_R {}; class C_R_26 : C_R {}; class C_R_27 : C_R {}; class C_R_28 : C_R {}; class C_R_29 : C_R {}; class C_R_30 : C_R {}; class C_R_31 : C_R {}; class C_R_32 : C_R {}; class C_R_33 : C_R {}; class C_R_34 : C_R {}; class C_R_35 : C_R {}; class C_R_36 : C_R {}; class C_R_37 : C_R {}; class C_R_38 : C_R {}; class C_R_39 : C_R {}; class C_R_40 : C_R {}; class C_R_41 : C_R {}; class C_R_42 : C_R {}; class C_R_43 : C_R {}; class C_R_44 : C_R {}; class C_R_45 : C_R {}; class C_R_46 : C_R {}; class C_R_47 : C_R {}; class C_R_48 : C_R {}; class C_R_49 : C_R {}; class C_R_50 : C_R {};
-// ====================================================================================
-class C_AT {               // "AT"        | ANTI-TANK JAV
-    uniform         = "rhs_uniform_cu_ocp_1stcav";
-    vest            = "rhsusf_iotv_ocp_Rifleman";
-    headgear        = "rhsusf_ach_helmet_ocp";
-    goggles         = "rhs_googles_clear";
-    nvgoggles       = "rhsusf_ANPVS_14";
-    backpack        = "rhsusf_assault_eagleaiii_ocp";
-    
-    primaryWeapon   = _WEAPON_PRIMARY0;
-    primaryWeaponAttachments[] = {
-        "acc_pointer_IR",
-        "RH_ta31rmr_2D"
-    };
-    
-    secondaryWeapon = _WEAPON_LAUNCHER0;
-    handgunWeapon = "";
-    
-    items[] = {};
-    magazines[] = {};
-    addItemsToUniform[] = {
-        _QUA10(ACE_FieldDressing),
-        _QUA2(ACE_morphine),
-        _QUA2(ACE_epinephrine),
-        _QUA1(ACE_tourniquet),
-        
-        _QUA2(ACE_CableTie),
-        
-        //_QUA1(_ITEM_RADIO1),
-        //_QUA1(_ITEM_RADIOADD),
-        
-        _QUA1(ACE_EarPlugs),
-        _QUA1(ACE_Flashlight_MX991),
-        _QUA1(ACE_DAGR),
-        _QUA1(ACE_MapTools),
-        _QUA1(ACE_IR_Strobe_Item),
-        _QUA2(_GRENADE)							
-    };
-    addItemsToVest[] = {
-        _QUA6(_MAG_PRIMARY),
-        _QUA2(_GRENADE),	
-        _QUA4(_GRENADE_SMOKE)							
-    };
-    addItemsToBackpack[] = {
-        _QUA2(_MAG_PRIMARY),
-        _QUA2(_GRENADE),	
-        _QUA4(_GRENADE_SMOKE),	
-        _QUA2(Chemlight_Blue),
-        _QUA2(Chemlight_Red),
-        _QUA1(_MAG_LAUNCHER0)						
-    };
-    
-    binoculars      = "";
-    map             = "ItemMap";
-    gps             = "";
-    compass         = "ItemCompass";
-    watch           = "tf_microdagr";
-};
-class C_AT_1 : C_AT {}; class C_AT_2 : C_AT {}; class C_AT_3 : C_AT {}; class C_AT_4 : C_AT {}; class C_AT_5 : C_AT {}; class C_AT_6 : C_AT {}; class C_AT_7 : C_AT {}; class C_AT_8 : C_AT {}; class C_AT_9 : C_AT {}; class C_AT_10 : C_AT {}; class C_AT_11 : C_AT {}; class C_AT_12 : C_AT {}; class C_AT_13 : C_AT {}; class C_AT_14 : C_AT {}; class C_AT_15 : C_AT {}; class C_AT_16 : C_AT {}; class C_AT_17 : C_AT {}; class C_AT_18 : C_AT {}; class C_AT_19 : C_AT {}; class C_AT_20 : C_AT {}; class C_AT_21 : C_AT {}; class C_AT_22 : C_AT {}; class C_AT_23 : C_AT {}; class C_AT_24 : C_AT {}; class C_AT_25 : C_AT {}; class C_AT_26 : C_AT {}; class C_AT_27 : C_AT {}; class C_AT_28 : C_AT {}; class C_AT_29 : C_AT {}; class C_AT_30 : C_AT {}; class C_AT_31 : C_AT {}; class C_AT_32 : C_AT {}; class C_AT_33 : C_AT {}; class C_AT_34 : C_AT {}; class C_AT_35 : C_AT {}; class C_AT_36 : C_AT {}; class C_AT_37 : C_AT {}; class C_AT_38 : C_AT {}; class C_AT_39 : C_AT {}; class C_AT_40 : C_AT {}; class C_AT_41 : C_AT {}; class C_AT_42 : C_AT {}; class C_AT_43 : C_AT {}; class C_AT_44 : C_AT {}; class C_AT_45 : C_AT {}; class C_AT_46 : C_AT {}; class C_AT_47 : C_AT {}; class C_AT_48 : C_AT {}; class C_AT_49 : C_AT {}; class C_AT_50 : C_AT {};
-// ====================================================================================
+
 class C_SL {               // "SL"        | SQUAD LEADER
     uniform         = "rhs_uniform_cu_ocp_1stcav";
     vest            = "rhsusf_iotv_ocp_Squadleader";
@@ -205,7 +146,7 @@ class C_SL {               // "SL"        | SQUAD LEADER
     items[] = {};
     magazines[] = {};
     addItemsToUniform[] = {
-        _QUA10(ACE_FieldDressing),
+        _QUA10(ACE_packingBandage),
         _QUA2(ACE_morphine),
         _QUA2(ACE_epinephrine),
         _QUA1(ACE_tourniquet),
@@ -250,7 +191,7 @@ class C_SL {               // "SL"        | SQUAD LEADER
     watch           = "tf_microdagr";
 };
 class C_SL_1 : C_SL {}; class C_SL_2 : C_SL {}; class C_SL_3 : C_SL {}; class C_SL_4 : C_SL {}; class C_SL_5 : C_SL {}; class C_SL_6 : C_SL {}; class C_SL_7 : C_SL {}; class C_SL_8 : C_SL {}; class C_SL_9 : C_SL {}; class C_SL_10 : C_SL {}; class C_SL_11 : C_SL {}; class C_SL_12 : C_SL {}; class C_SL_13 : C_SL {}; class C_SL_14 : C_SL {}; class C_SL_15 : C_SL {}; class C_SL_16 : C_SL {}; class C_SL_17 : C_SL {}; class C_SL_18 : C_SL {}; class C_SL_19 : C_SL {}; class C_SL_20 : C_SL {}; class C_SL_21 : C_SL {}; class C_SL_22 : C_SL {}; class C_SL_23 : C_SL {}; class C_SL_24 : C_SL {}; class C_SL_25 : C_SL {}; class C_SL_26 : C_SL {}; class C_SL_27 : C_SL {}; class C_SL_28 : C_SL {}; class C_SL_29 : C_SL {}; class C_SL_30 : C_SL {}; class C_SL_31 : C_SL {}; class C_SL_32 : C_SL {}; class C_SL_33 : C_SL {}; class C_SL_34 : C_SL {}; class C_SL_35 : C_SL {}; class C_SL_36 : C_SL {}; class C_SL_37 : C_SL {}; class C_SL_38 : C_SL {}; class C_SL_39 : C_SL {}; class C_SL_40 : C_SL {}; class C_SL_41 : C_SL {}; class C_SL_42 : C_SL {}; class C_SL_43 : C_SL {}; class C_SL_44 : C_SL {}; class C_SL_45 : C_SL {}; class C_SL_46 : C_SL {}; class C_SL_47 : C_SL {}; class C_SL_48 : C_SL {}; class C_SL_49 : C_SL {}; class C_SL_50 : C_SL {};
-// ====================================================================================
+
 class C_FTL {             // "FTL"       | FIRE TEAM LEADER
     uniform         = "rhs_uniform_cu_ocp_1stcav";
     vest            = "rhsusf_iotv_ocp_Teamleader";
@@ -271,7 +212,7 @@ class C_FTL {             // "FTL"       | FIRE TEAM LEADER
     items[] = {};
     magazines[] = {};
     addItemsToUniform[] = {
-        _QUA10(ACE_FieldDressing),
+        _QUA10(ACE_packingBandage),
         _QUA2(ACE_morphine),
         _QUA2(ACE_epinephrine),
         _QUA1(ACE_tourniquet),
@@ -283,7 +224,7 @@ class C_FTL {             // "FTL"       | FIRE TEAM LEADER
         
         _QUA1(ACE_EarPlugs),
         _QUA1(ACE_Flashlight_MX991),
-        _QUA1(ACE_DAGR),
+        _QUA1(ACE_microDAGR),
         _QUA1(ACE_MapTools),
         _QUA1(ACE_IR_Strobe_Item),
         _QUA2(_GRENADE)							
@@ -319,7 +260,7 @@ class C_FTL {             // "FTL"       | FIRE TEAM LEADER
     watch           = "tf_microdagr";
 };
 class C_FTL_1 : C_FTL {}; class C_FTL_2 : C_FTL {}; class C_FTL_3 : C_FTL {}; class C_FTL_4 : C_FTL {}; class C_FTL_5 : C_FTL {}; class C_FTL_6 : C_FTL {}; class C_FTL_7 : C_FTL {}; class C_FTL_8 : C_FTL {}; class C_FTL_9 : C_FTL {}; class C_FTL_10 : C_FTL {}; class C_FTL_11 : C_FTL {}; class C_FTL_12 : C_FTL {}; class C_FTL_13 : C_FTL {}; class C_FTL_14 : C_FTL {}; class C_FTL_15 : C_FTL {}; class C_FTL_16 : C_FTL {}; class C_FTL_17 : C_FTL {}; class C_FTL_18 : C_FTL {}; class C_FTL_19 : C_FTL {}; class C_FTL_20 : C_FTL {}; class C_FTL_21 : C_FTL {}; class C_FTL_22 : C_FTL {}; class C_FTL_23 : C_FTL {}; class C_FTL_24 : C_FTL {}; class C_FTL_25 : C_FTL {}; class C_FTL_26 : C_FTL {}; class C_FTL_27 : C_FTL {}; class C_FTL_28 : C_FTL {}; class C_FTL_29 : C_FTL {}; class C_FTL_30 : C_FTL {}; class C_FTL_31 : C_FTL {}; class C_FTL_32 : C_FTL {}; class C_FTL_33 : C_FTL {}; class C_FTL_34 : C_FTL {}; class C_FTL_35 : C_FTL {}; class C_FTL_36 : C_FTL {}; class C_FTL_37 : C_FTL {}; class C_FTL_38 : C_FTL {}; class C_FTL_39 : C_FTL {}; class C_FTL_40 : C_FTL {}; class C_FTL_41 : C_FTL {}; class C_FTL_42 : C_FTL {}; class C_FTL_43 : C_FTL {}; class C_FTL_44 : C_FTL {}; class C_FTL_45 : C_FTL {}; class C_FTL_46 : C_FTL {}; class C_FTL_47 : C_FTL {}; class C_FTL_48 : C_FTL {}; class C_FTL_49 : C_FTL {}; class C_FTL_50 : C_FTL {};
-// ====================================================================================
+
 class C_M {                  // "M"         | COMBAT LIFESAVER
     uniform         = "rhs_uniform_cu_ocp_1stcav";
     vest            = "rhsusf_iotv_ocp_Medic";
@@ -371,8 +312,6 @@ class C_M {                  // "M"         | COMBAT LIFESAVER
         _QUA2(Chemlight_Red),	
         _QUA10(ACE_packingBandage),
         _QUA10(ACE_elasticBandage),	
-        _QUA10(ACE_FieldDressing),
-        _QUA10(ACE_quikclot),	
         _QUA2(ACE_salineIV),
         _QUA2(ACE_salineIV_500)				
     };
@@ -384,8 +323,8 @@ class C_M {                  // "M"         | COMBAT LIFESAVER
     watch           = "tf_microdagr";
 };
 class C_M_1 : C_M {}; class C_M_2 : C_M {}; class C_M_3 : C_M {}; class C_M_4 : C_M {}; class C_M_5 : C_M {}; class C_M_6 : C_M {}; class C_M_7 : C_M {}; class C_M_8 : C_M {}; class C_M_9 : C_M {}; class C_M_10 : C_M {}; class C_M_11 : C_M {}; class C_M_12 : C_M {}; class C_M_13 : C_M {}; class C_M_14 : C_M {}; class C_M_15 : C_M {}; class C_M_16 : C_M {}; class C_M_17 : C_M {}; class C_M_18 : C_M {}; class C_M_19 : C_M {}; class C_M_20 : C_M {}; class C_M_21 : C_M {}; class C_M_22 : C_M {}; class C_M_23 : C_M {}; class C_M_24 : C_M {}; class C_M_25 : C_M {}; class C_M_26 : C_M {}; class C_M_27 : C_M {}; class C_M_28 : C_M {}; class C_M_29 : C_M {}; class C_M_30 : C_M {}; class C_M_31 : C_M {}; class C_M_32 : C_M {}; class C_M_33 : C_M {}; class C_M_34 : C_M {}; class C_M_35 : C_M {}; class C_M_36 : C_M {}; class C_M_37 : C_M {}; class C_M_38 : C_M {}; class C_M_39 : C_M {}; class C_M_40 : C_M {}; class C_M_41 : C_M {}; class C_M_42 : C_M {}; class C_M_43 : C_M {}; class C_M_44 : C_M {}; class C_M_45 : C_M {}; class C_M_46 : C_M {}; class C_M_47 : C_M {}; class C_M_48 : C_M {}; class C_M_49 : C_M {}; class C_M_50 : C_M {};
-// ====================================================================================
-class C_AR {             // "AR"        | AUTOMATIC RIFLEMAN
+
+class C_AR {             // "ARL"        | AUTOMATIC RIFLEMAN
     uniform         = "rhs_uniform_cu_ocp_1stcav";
     vest            = "rhsusf_iotv_ocp_SAW";
     headgear        = "rhsusf_ach_helmet_ocp";
@@ -405,7 +344,7 @@ class C_AR {             // "AR"        | AUTOMATIC RIFLEMAN
     items[] = {};
     magazines[] = {};
     addItemsToUniform[] = {
-        _QUA10(ACE_FieldDressing),
+        _QUA10(ACE_packingBandage),
         _QUA2(ACE_morphine),
         _QUA2(ACE_epinephrine),
         _QUA1(ACE_tourniquet),
@@ -443,7 +382,9 @@ class C_AR {             // "AR"        | AUTOMATIC RIFLEMAN
     watch           = "tf_microdagr";
 };
 class C_AR_1 : C_AR {}; class C_AR_2 : C_AR {}; class C_AR_3 : C_AR {}; class C_AR_4 : C_AR {}; class C_AR_5 : C_AR {}; class C_AR_6 : C_AR {}; class C_AR_7 : C_AR {}; class C_AR_8 : C_AR {}; class C_AR_9 : C_AR {}; class C_AR_10 : C_AR {}; class C_AR_11 : C_AR {}; class C_AR_12 : C_AR {}; class C_AR_13 : C_AR {}; class C_AR_14 : C_AR {}; class C_AR_15 : C_AR {}; class C_AR_16 : C_AR {}; class C_AR_17 : C_AR {}; class C_AR_18 : C_AR {}; class C_AR_19 : C_AR {}; class C_AR_20 : C_AR {}; class C_AR_21 : C_AR {}; class C_AR_22 : C_AR {}; class C_AR_23 : C_AR {}; class C_AR_24 : C_AR {}; class C_AR_25 : C_AR {}; class C_AR_26 : C_AR {}; class C_AR_27 : C_AR {}; class C_AR_28 : C_AR {}; class C_AR_29 : C_AR {}; class C_AR_30 : C_AR {}; class C_AR_31 : C_AR {}; class C_AR_32 : C_AR {}; class C_AR_33 : C_AR {}; class C_AR_34 : C_AR {}; class C_AR_35 : C_AR {}; class C_AR_36 : C_AR {}; class C_AR_37 : C_AR {}; class C_AR_38 : C_AR {}; class C_AR_39 : C_AR {}; class C_AR_40 : C_AR {}; class C_AR_41 : C_AR {}; class C_AR_42 : C_AR {}; class C_AR_43 : C_AR {}; class C_AR_44 : C_AR {}; class C_AR_45 : C_AR {}; class C_AR_46 : C_AR {}; class C_AR_47 : C_AR {}; class C_AR_48 : C_AR {}; class C_AR_49 : C_AR {}; class C_AR_50 : C_AR {};
-// ====================================================================================
+class C_ARL : C_AR {}; 
+class C_ARL_1 : C_ARL {}; class C_ARL_2 : C_ARL {}; class C_ARL_3 : C_ARL {}; class C_ARL_4 : C_ARL {}; class C_ARL_5 : C_ARL {}; class C_ARL_6 : C_ARL {}; class C_ARL_7 : C_ARL {}; class C_ARL_8 : C_ARL {}; class C_ARL_9 : C_ARL {}; class C_ARL_10 : C_ARL {}; class C_ARL_11 : C_ARL {}; class C_ARL_12 : C_ARL {}; class C_ARL_13 : C_ARL {}; class C_ARL_14 : C_ARL {}; class C_ARL_15 : C_ARL {}; class C_ARL_16 : C_ARL {}; class C_ARL_17 : C_ARL {}; class C_ARL_18 : C_ARL {}; class C_ARL_19 : C_ARL {}; class C_ARL_20 : C_ARL {}; class C_ARL_21 : C_ARL {}; class C_ARL_22 : C_ARL {}; class C_ARL_23 : C_ARL {}; class C_ARL_24 : C_ARL {}; class C_ARL_25 : C_ARL {}; class C_ARL_26 : C_ARL {}; class C_ARL_27 : C_ARL {}; class C_ARL_28 : C_ARL {}; class C_ARL_29 : C_ARL {}; class C_ARL_30 : C_ARL {}; class C_ARL_31 : C_ARL {}; class C_ARL_32 : C_ARL {}; class C_ARL_33 : C_ARL {}; class C_ARL_34 : C_ARL {}; class C_ARL_35 : C_ARL {}; class C_ARL_36 : C_ARL {}; class C_ARL_37 : C_ARL {}; class C_ARL_38 : C_ARL {}; class C_ARL_39 : C_ARL {}; class C_ARL_40 : C_ARL {}; class C_ARL_41 : C_ARL {}; class C_ARL_42 : C_ARL {}; class C_ARL_43 : C_ARL {}; class C_ARL_44 : C_ARL {}; class C_ARL_45 : C_ARL {}; class C_ARL_46 : C_ARL {}; class C_ARL_47 : C_ARL {}; class C_ARL_48 : C_ARL {}; class C_ARL_49 : C_ARL {}; class C_ARL_50 : C_ARL {};
+
 class C_MOG {           // "MOG"       | MORTAR GUNNER
     uniform         = "rhs_uniform_cu_ocp_1stcav";
     vest            = "rhsusf_iotv_ocp_Repair";
@@ -464,7 +405,7 @@ class C_MOG {           // "MOG"       | MORTAR GUNNER
     items[] = {};
     magazines[] = {};
     addItemsToUniform[] = {
-        _QUA10(ACE_FieldDressing),
+        _QUA10(ACE_packingBandage),
         _QUA2(ACE_morphine),
         _QUA2(ACE_epinephrine),
         _QUA1(ACE_tourniquet),
@@ -495,7 +436,7 @@ class C_MOG {           // "MOG"       | MORTAR GUNNER
     watch           = "tf_microdagr";
 };
 class C_MOG_1 : C_MOG {}; class C_MOG_2 : C_MOG {}; class C_MOG_3 : C_MOG {}; class C_MOG_4 : C_MOG {}; class C_MOG_5 : C_MOG {}; class C_MOG_6 : C_MOG {}; class C_MOG_7 : C_MOG {}; class C_MOG_8 : C_MOG {}; class C_MOG_9 : C_MOG {}; class C_MOG_10 : C_MOG {}; class C_MOG_11 : C_MOG {}; class C_MOG_12 : C_MOG {}; class C_MOG_13 : C_MOG {}; class C_MOG_14 : C_MOG {}; class C_MOG_15 : C_MOG {}; class C_MOG_16 : C_MOG {}; class C_MOG_17 : C_MOG {}; class C_MOG_18 : C_MOG {}; class C_MOG_19 : C_MOG {}; class C_MOG_20 : C_MOG {}; class C_MOG_21 : C_MOG {}; class C_MOG_22 : C_MOG {}; class C_MOG_23 : C_MOG {}; class C_MOG_24 : C_MOG {}; class C_MOG_25 : C_MOG {}; class C_MOG_26 : C_MOG {}; class C_MOG_27 : C_MOG {}; class C_MOG_28 : C_MOG {}; class C_MOG_29 : C_MOG {}; class C_MOG_30 : C_MOG {}; class C_MOG_31 : C_MOG {}; class C_MOG_32 : C_MOG {}; class C_MOG_33 : C_MOG {}; class C_MOG_34 : C_MOG {}; class C_MOG_35 : C_MOG {}; class C_MOG_36 : C_MOG {}; class C_MOG_37 : C_MOG {}; class C_MOG_38 : C_MOG {}; class C_MOG_39 : C_MOG {}; class C_MOG_40 : C_MOG {}; class C_MOG_41 : C_MOG {}; class C_MOG_42 : C_MOG {}; class C_MOG_43 : C_MOG {}; class C_MOG_44 : C_MOG {}; class C_MOG_45 : C_MOG {}; class C_MOG_46 : C_MOG {}; class C_MOG_47 : C_MOG {}; class C_MOG_48 : C_MOG {}; class C_MOG_49 : C_MOG {}; class C_MOG_50 : C_MOG {};
-// ====================================================================================
+
 class C_MOA {          // "MOA"       | MORTAR ASST.
     uniform         = "rhs_uniform_cu_ocp_1stcav";
     vest            = "rhsusf_iotv_ocp_Repair";
@@ -516,7 +457,7 @@ class C_MOA {          // "MOA"       | MORTAR ASST.
     items[] = {};
     magazines[] = {};
     addItemsToUniform[] = {
-        _QUA10(ACE_FieldDressing),
+        _QUA10(ACE_packingBandage),
         _QUA2(ACE_morphine),
         _QUA2(ACE_epinephrine),
         _QUA1(ACE_tourniquet),
@@ -547,66 +488,7 @@ class C_MOA {          // "MOA"       | MORTAR ASST.
     watch           = "tf_microdagr";
 };
 class C_MOA_1 : C_MOA {}; class C_MOA_2 : C_MOA {}; class C_MOA_3 : C_MOA {}; class C_MOA_4 : C_MOA {}; class C_MOA_5 : C_MOA {}; class C_MOA_6 : C_MOA {}; class C_MOA_7 : C_MOA {}; class C_MOA_8 : C_MOA {}; class C_MOA_9 : C_MOA {}; class C_MOA_10 : C_MOA {}; class C_MOA_11 : C_MOA {}; class C_MOA_12 : C_MOA {}; class C_MOA_13 : C_MOA {}; class C_MOA_14 : C_MOA {}; class C_MOA_15 : C_MOA {}; class C_MOA_16 : C_MOA {}; class C_MOA_17 : C_MOA {}; class C_MOA_18 : C_MOA {}; class C_MOA_19 : C_MOA {}; class C_MOA_20 : C_MOA {}; class C_MOA_21 : C_MOA {}; class C_MOA_22 : C_MOA {}; class C_MOA_23 : C_MOA {}; class C_MOA_24 : C_MOA {}; class C_MOA_25 : C_MOA {}; class C_MOA_26 : C_MOA {}; class C_MOA_27 : C_MOA {}; class C_MOA_28 : C_MOA {}; class C_MOA_29 : C_MOA {}; class C_MOA_30 : C_MOA {}; class C_MOA_31 : C_MOA {}; class C_MOA_32 : C_MOA {}; class C_MOA_33 : C_MOA {}; class C_MOA_34 : C_MOA {}; class C_MOA_35 : C_MOA {}; class C_MOA_36 : C_MOA {}; class C_MOA_37 : C_MOA {}; class C_MOA_38 : C_MOA {}; class C_MOA_39 : C_MOA {}; class C_MOA_40 : C_MOA {}; class C_MOA_41 : C_MOA {}; class C_MOA_42 : C_MOA {}; class C_MOA_43 : C_MOA {}; class C_MOA_44 : C_MOA {}; class C_MOA_45 : C_MOA {}; class C_MOA_46 : C_MOA {}; class C_MOA_47 : C_MOA {}; class C_MOA_48 : C_MOA {}; class C_MOA_49 : C_MOA {}; class C_MOA_50 : C_MOA {};
-// ====================================================================================
-class C_AA {             // "AA"        | ANTI-AIR
-    uniform         = "rhs_uniform_cu_ocp_1stcav";
-    vest            = "rhsusf_iotv_ocp_Rifleman";
-    headgear        = "rhsusf_ach_helmet_ocp";
-    goggles         = "rhs_googles_clear";
-    nvgoggles       = "rhsusf_ANPVS_14";
-    backpack        = "rhsusf_assault_eagleaiii_ocp";
-    
-    primaryWeapon   = _WEAPON_LAUNCHER1;
-    primaryWeaponAttachments[] = {
-        "acc_pointer_IR",
-        "RH_ta31rmr_2D"
-    };
-    
-    secondaryWeapon = _WEAPON_LAUNCHER1;
-    handgunWeapon = "";
-    
-    items[] = {};
-    magazines[] = {};
-    addItemsToUniform[] = {
-        _QUA10(ACE_FieldDressing),
-        _QUA2(ACE_morphine),
-        _QUA2(ACE_epinephrine),
-        _QUA1(ACE_tourniquet),
-        
-        _QUA2(ACE_CableTie),
-        
-        //_QUA1(_ITEM_RADIO1),
-        //_QUA1(_ITEM_RADIOADD),
-        
-        _QUA1(ACE_EarPlugs),
-        _QUA1(ACE_Flashlight_MX991),
-        _QUA1(ACE_DAGR),
-        _QUA1(ACE_MapTools),
-        _QUA1(ACE_IR_Strobe_Item),
-        _QUA2(_GRENADE)							
-    };
-    addItemsToVest[] = {
-        _QUA6(_MAG_PRIMARY),
-        _QUA2(_GRENADE),	
-        _QUA4(_GRENADE_SMOKE)							
-    };
-    addItemsToBackpack[] = {
-        _QUA2(_MAG_PRIMARY),
-        _QUA2(_GRENADE),	
-        _QUA4(_GRENADE_SMOKE),	
-        _QUA2(Chemlight_Blue),
-        _QUA2(Chemlight_Red),
-        _QUA1(_MAG_LAUNCHER1)						
-    };
-    
-    binoculars      = "";
-    map             = "ItemMap";
-    gps             = "";
-    compass         = "ItemCompass";
-    watch           = "tf_microdagr";
-};
-class C_AA_1 : C_AA {}; class C_AA_2 : C_AA {}; class C_AA_3 : C_AA {}; class C_AA_4 : C_AA {}; class C_AA_5 : C_AA {}; class C_AA_6 : C_AA {}; class C_AA_7 : C_AA {}; class C_AA_8 : C_AA {}; class C_AA_9 : C_AA {}; class C_AA_10 : C_AA {}; class C_AA_11 : C_AA {}; class C_AA_12 : C_AA {}; class C_AA_13 : C_AA {}; class C_AA_14 : C_AA {}; class C_AA_15 : C_AA {}; class C_AA_16 : C_AA {}; class C_AA_17 : C_AA {}; class C_AA_18 : C_AA {}; class C_AA_19 : C_AA {}; class C_AA_20 : C_AA {}; class C_AA_21 : C_AA {}; class C_AA_22 : C_AA {}; class C_AA_23 : C_AA {}; class C_AA_24 : C_AA {}; class C_AA_25 : C_AA {}; class C_AA_26 : C_AA {}; class C_AA_27 : C_AA {}; class C_AA_28 : C_AA {}; class C_AA_29 : C_AA {}; class C_AA_30 : C_AA {}; class C_AA_31 : C_AA {}; class C_AA_32 : C_AA {}; class C_AA_33 : C_AA {}; class C_AA_34 : C_AA {}; class C_AA_35 : C_AA {}; class C_AA_36 : C_AA {}; class C_AA_37 : C_AA {}; class C_AA_38 : C_AA {}; class C_AA_39 : C_AA {}; class C_AA_40 : C_AA {}; class C_AA_41 : C_AA {}; class C_AA_42 : C_AA {}; class C_AA_43 : C_AA {}; class C_AA_44 : C_AA {}; class C_AA_45 : C_AA {}; class C_AA_46 : C_AA {}; class C_AA_47 : C_AA {}; class C_AA_48 : C_AA {}; class C_AA_49 : C_AA {}; class C_AA_50 : C_AA {};
-// ====================================================================================
+
 class C_ENG {               // "ENG"       | ENGINEER
     uniform         = "rhs_uniform_cu_ocp_1stcav";
     vest            = "rhsusf_iotv_ocp_Repair";
@@ -627,7 +509,7 @@ class C_ENG {               // "ENG"       | ENGINEER
     items[] = {};
     magazines[] = {};
     addItemsToUniform[] = {
-        _QUA10(ACE_FieldDressing),
+        _QUA10(ACE_packingBandage),
         _QUA2(ACE_morphine),
         _QUA2(ACE_epinephrine),
         _QUA1(ACE_tourniquet),
@@ -665,7 +547,7 @@ class C_ENG {               // "ENG"       | ENGINEER
     watch           = "tf_microdagr";
 };
 class C_ENG_1 : C_ENG {}; class C_ENG_2 : C_ENG {}; class C_ENG_3 : C_ENG {}; class C_ENG_4 : C_ENG {}; class C_ENG_5 : C_ENG {}; class C_ENG_6 : C_ENG {}; class C_ENG_7 : C_ENG {}; class C_ENG_8 : C_ENG {}; class C_ENG_9 : C_ENG {}; class C_ENG_10 : C_ENG {}; class C_ENG_11 : C_ENG {}; class C_ENG_12 : C_ENG {}; class C_ENG_13 : C_ENG {}; class C_ENG_14 : C_ENG {}; class C_ENG_15 : C_ENG {}; class C_ENG_16 : C_ENG {}; class C_ENG_17 : C_ENG {}; class C_ENG_18 : C_ENG {}; class C_ENG_19 : C_ENG {}; class C_ENG_20 : C_ENG {}; class C_ENG_21 : C_ENG {}; class C_ENG_22 : C_ENG {}; class C_ENG_23 : C_ENG {}; class C_ENG_24 : C_ENG {}; class C_ENG_25 : C_ENG {}; class C_ENG_26 : C_ENG {}; class C_ENG_27 : C_ENG {}; class C_ENG_28 : C_ENG {}; class C_ENG_29 : C_ENG {}; class C_ENG_30 : C_ENG {}; class C_ENG_31 : C_ENG {}; class C_ENG_32 : C_ENG {}; class C_ENG_33 : C_ENG {}; class C_ENG_34 : C_ENG {}; class C_ENG_35 : C_ENG {}; class C_ENG_36 : C_ENG {}; class C_ENG_37 : C_ENG {}; class C_ENG_38 : C_ENG {}; class C_ENG_39 : C_ENG {}; class C_ENG_40 : C_ENG {}; class C_ENG_41 : C_ENG {}; class C_ENG_42 : C_ENG {}; class C_ENG_43 : C_ENG {}; class C_ENG_44 : C_ENG {}; class C_ENG_45 : C_ENG {}; class C_ENG_46 : C_ENG {}; class C_ENG_47 : C_ENG {}; class C_ENG_48 : C_ENG {}; class C_ENG_49 : C_ENG {}; class C_ENG_50 : C_ENG {};
-// ====================================================================================
+
 class C_AR2 {            // "AR2"       | AUTOMATIC RIFLEMAN 2
     uniform         = "rhs_uniform_cu_ocp_1stcav";
     vest            = "rhsusf_iotv_ocp_SAW";
@@ -686,7 +568,7 @@ class C_AR2 {            // "AR2"       | AUTOMATIC RIFLEMAN 2
     items[] = {};
     magazines[] = {};
     addItemsToUniform[] = {
-        _QUA10(ACE_FieldDressing),
+        _QUA10(ACE_packingBandage),
         _QUA2(ACE_morphine),
         _QUA2(ACE_epinephrine),
         _QUA1(ACE_tourniquet),
@@ -724,65 +606,9 @@ class C_AR2 {            // "AR2"       | AUTOMATIC RIFLEMAN 2
     watch           = "tf_microdagr";
 };
 class C_AR2_1 : C_AR2 {}; class C_AR2_2 : C_AR2 {}; class C_AR2_3 : C_AR2 {}; class C_AR2_4 : C_AR2 {}; class C_AR2_5 : C_AR2 {}; class C_AR2_6 : C_AR2 {}; class C_AR2_7 : C_AR2 {}; class C_AR2_8 : C_AR2 {}; class C_AR2_9 : C_AR2 {}; class C_AR2_10 : C_AR2 {}; class C_AR2_11 : C_AR2 {}; class C_AR2_12 : C_AR2 {}; class C_AR2_13 : C_AR2 {}; class C_AR2_14 : C_AR2 {}; class C_AR2_15 : C_AR2 {}; class C_AR2_16 : C_AR2 {}; class C_AR2_17 : C_AR2 {}; class C_AR2_18 : C_AR2 {}; class C_AR2_19 : C_AR2 {}; class C_AR2_20 : C_AR2 {}; class C_AR2_21 : C_AR2 {}; class C_AR2_22 : C_AR2 {}; class C_AR2_23 : C_AR2 {}; class C_AR2_24 : C_AR2 {}; class C_AR2_25 : C_AR2 {}; class C_AR2_26 : C_AR2 {}; class C_AR2_27 : C_AR2 {}; class C_AR2_28 : C_AR2 {}; class C_AR2_29 : C_AR2 {}; class C_AR2_30 : C_AR2 {}; class C_AR2_31 : C_AR2 {}; class C_AR2_32 : C_AR2 {}; class C_AR2_33 : C_AR2 {}; class C_AR2_34 : C_AR2 {}; class C_AR2_35 : C_AR2 {}; class C_AR2_36 : C_AR2 {}; class C_AR2_37 : C_AR2 {}; class C_AR2_38 : C_AR2 {}; class C_AR2_39 : C_AR2 {}; class C_AR2_40 : C_AR2 {}; class C_AR2_41 : C_AR2 {}; class C_AR2_42 : C_AR2 {}; class C_AR2_43 : C_AR2 {}; class C_AR2_44 : C_AR2 {}; class C_AR2_45 : C_AR2 {}; class C_AR2_46 : C_AR2 {}; class C_AR2_47 : C_AR2 {}; class C_AR2_48 : C_AR2 {}; class C_AR2_49 : C_AR2 {}; class C_AR2_50 : C_AR2 {};
-// ====================================================================================
-class C_ATL {            // "ATL"       | LIGHT ANTI-TANK
-    uniform         = "rhs_uniform_cu_ocp_1stcav";
-    vest            = "rhsusf_iotv_ocp_Rifleman";
-    headgear        = "rhsusf_ach_helmet_ocp";
-    goggles         = "rhs_googles_clear";
-    nvgoggles       = "rhsusf_ANPVS_14";
-    backpack        = "rhsusf_assault_eagleaiii_ocp";
-    
-    primaryWeapon   = _WEAPON_PRIMARY0;
-    primaryWeaponAttachments[] = {
-        "acc_pointer_IR",
-        "RH_ta31rmr_2D"
-    };
-    
-    secondaryWeapon = _WEAPON_LAUNCHER2;
-    handgunWeapon = "";
-    
-    items[] = {};
-    magazines[] = {};
-    addItemsToUniform[] = {
-        _QUA10(ACE_FieldDressing),
-        _QUA2(ACE_morphine),
-        _QUA2(ACE_epinephrine),
-        _QUA1(ACE_tourniquet),
-        
-        _QUA2(ACE_CableTie),
-        
-        //_QUA1(_ITEM_RADIO1),
-        //_QUA1(_ITEM_RADIOADD),
-        
-        _QUA1(ACE_EarPlugs),
-        _QUA1(ACE_Flashlight_MX991),
-        _QUA1(ACE_DAGR),
-        _QUA1(ACE_MapTools),
-        _QUA1(ACE_IR_Strobe_Item),
-        _QUA2(_GRENADE)							
-    };
-    addItemsToVest[] = {
-        _QUA4(_MAG_PRIMARY),
-        _QUA2(_GRENADE),	
-        _QUA4(_GRENADE_SMOKE)							
-    };
-    addItemsToBackpack[] = {
-        _QUA4(_MAG_PRIMARY),
-        _QUA2(_GRENADE),	
-        _QUA4(_GRENADE_SMOKE),	
-        _QUA2(Chemlight_Blue),
-        _QUA2(Chemlight_Red)						
-    };
-    
-    binoculars      = "";
-    map             = "ItemMap";
-    gps             = "";
-    compass         = "ItemCompass";
-    watch           = "tf_microdagr";
-};
-class C_ATL_1 : C_ATL {}; class C_ATL_2 : C_ATL {}; class C_ATL_3 : C_ATL {}; class C_ATL_4 : C_ATL {}; class C_ATL_5 : C_ATL {}; class C_ATL_6 : C_ATL {}; class C_ATL_7 : C_ATL {}; class C_ATL_8 : C_ATL {}; class C_ATL_9 : C_ATL {}; class C_ATL_10 : C_ATL {}; class C_ATL_11 : C_ATL {}; class C_ATL_12 : C_ATL {}; class C_ATL_13 : C_ATL {}; class C_ATL_14 : C_ATL {}; class C_ATL_15 : C_ATL {}; class C_ATL_16 : C_ATL {}; class C_ATL_17 : C_ATL {}; class C_ATL_18 : C_ATL {}; class C_ATL_19 : C_ATL {}; class C_ATL_20 : C_ATL {}; class C_ATL_21 : C_ATL {}; class C_ATL_22 : C_ATL {}; class C_ATL_23 : C_ATL {}; class C_ATL_24 : C_ATL {}; class C_ATL_25 : C_ATL {}; class C_ATL_26 : C_ATL {}; class C_ATL_27 : C_ATL {}; class C_ATL_28 : C_ATL {}; class C_ATL_29 : C_ATL {}; class C_ATL_30 : C_ATL {}; class C_ATL_31 : C_ATL {}; class C_ATL_32 : C_ATL {}; class C_ATL_33 : C_ATL {}; class C_ATL_34 : C_ATL {}; class C_ATL_35 : C_ATL {}; class C_ATL_36 : C_ATL {}; class C_ATL_37 : C_ATL {}; class C_ATL_38 : C_ATL {}; class C_ATL_39 : C_ATL {}; class C_ATL_40 : C_ATL {}; class C_ATL_41 : C_ATL {}; class C_ATL_42 : C_ATL {}; class C_ATL_43 : C_ATL {}; class C_ATL_44 : C_ATL {}; class C_ATL_45 : C_ATL {}; class C_ATL_46 : C_ATL {}; class C_ATL_47 : C_ATL {}; class C_ATL_48 : C_ATL {}; class C_ATL_49 : C_ATL {}; class C_ATL_50 : C_ATL {};
-// ====================================================================================
+class C_ARM : C_AR2 {}; 
+class C_ARM_1 : C_ARM {}; class C_ARM_2 : C_ARM {}; class C_ARM_3 : C_ARM {}; class C_ARM_4 : C_ARM {}; class C_ARM_5 : C_ARM {}; class C_ARM_6 : C_ARM {}; class C_ARM_7 : C_ARM {}; class C_ARM_8 : C_ARM {}; class C_ARM_9 : C_ARM {}; class C_ARM_10 : C_ARM {}; class C_ARM_11 : C_ARM {}; class C_ARM_12 : C_ARM {}; class C_ARM_13 : C_ARM {}; class C_ARM_14 : C_ARM {}; class C_ARM_15 : C_ARM {}; class C_ARM_16 : C_ARM {}; class C_ARM_17 : C_ARM {}; class C_ARM_18 : C_ARM {}; class C_ARM_19 : C_ARM {}; class C_ARM_20 : C_ARM {}; class C_ARM_21 : C_ARM {}; class C_ARM_22 : C_ARM {}; class C_ARM_23 : C_ARM {}; class C_ARM_24 : C_ARM {}; class C_ARM_25 : C_ARM {}; class C_ARM_26 : C_ARM {}; class C_ARM_27 : C_ARM {}; class C_ARM_28 : C_ARM {}; class C_ARM_29 : C_ARM {}; class C_ARM_30 : C_ARM {}; class C_ARM_31 : C_ARM {}; class C_ARM_32 : C_ARM {}; class C_ARM_33 : C_ARM {}; class C_ARM_34 : C_ARM {}; class C_ARM_35 : C_ARM {}; class C_ARM_36 : C_ARM {}; class C_ARM_37 : C_ARM {}; class C_ARM_38 : C_ARM {}; class C_ARM_39 : C_ARM {}; class C_ARM_40 : C_ARM {}; class C_ARM_41 : C_ARM {}; class C_ARM_42 : C_ARM {}; class C_ARM_43 : C_ARM {}; class C_ARM_44 : C_ARM {}; class C_ARM_45 : C_ARM {}; class C_ARM_46 : C_ARM {}; class C_ARM_47 : C_ARM {}; class C_ARM_48 : C_ARM {}; class C_ARM_49 : C_ARM {}; class C_ARM_50 : C_ARM {};
+
 class C_JTAC {             // "JTAC"      | JTAC
     uniform         = "rhs_uniform_cu_ocp_1stcav";
     vest            = "rhsusf_iotv_ocp_Squadleader";
@@ -803,7 +629,7 @@ class C_JTAC {             // "JTAC"      | JTAC
     items[] = {};
     magazines[] = {};
     addItemsToUniform[] = {
-        _QUA10(ACE_FieldDressing),
+        _QUA10(ACE_packingBandage),
         _QUA2(ACE_morphine),
         _QUA2(ACE_epinephrine),
         _QUA1(ACE_tourniquet),
@@ -849,7 +675,7 @@ class C_JTAC {             // "JTAC"      | JTAC
     watch           = "tf_microdagr";
 };
 class C_JTAC_1 : C_JTAC {}; class C_JTAC_2 : C_JTAC {}; class C_JTAC_3 : C_JTAC {}; class C_JTAC_4 : C_JTAC {}; class C_JTAC_5 : C_JTAC {}; class C_JTAC_6 : C_JTAC {}; class C_JTAC_7 : C_JTAC {}; class C_JTAC_8 : C_JTAC {}; class C_JTAC_9 : C_JTAC {}; class C_JTAC_10 : C_JTAC {}; class C_JTAC_11 : C_JTAC {}; class C_JTAC_12 : C_JTAC {}; class C_JTAC_13 : C_JTAC {}; class C_JTAC_14 : C_JTAC {}; class C_JTAC_15 : C_JTAC {}; class C_JTAC_16 : C_JTAC {}; class C_JTAC_17 : C_JTAC {}; class C_JTAC_18 : C_JTAC {}; class C_JTAC_19 : C_JTAC {}; class C_JTAC_20 : C_JTAC {}; class C_JTAC_21 : C_JTAC {}; class C_JTAC_22 : C_JTAC {}; class C_JTAC_23 : C_JTAC {}; class C_JTAC_24 : C_JTAC {}; class C_JTAC_25 : C_JTAC {}; class C_JTAC_26 : C_JTAC {}; class C_JTAC_27 : C_JTAC {}; class C_JTAC_28 : C_JTAC {}; class C_JTAC_29 : C_JTAC {}; class C_JTAC_30 : C_JTAC {}; class C_JTAC_31 : C_JTAC {}; class C_JTAC_32 : C_JTAC {}; class C_JTAC_33 : C_JTAC {}; class C_JTAC_34 : C_JTAC {}; class C_JTAC_35 : C_JTAC {}; class C_JTAC_36 : C_JTAC {}; class C_JTAC_37 : C_JTAC {}; class C_JTAC_38 : C_JTAC {}; class C_JTAC_39 : C_JTAC {}; class C_JTAC_40 : C_JTAC {}; class C_JTAC_41 : C_JTAC {}; class C_JTAC_42 : C_JTAC {}; class C_JTAC_43 : C_JTAC {}; class C_JTAC_44 : C_JTAC {}; class C_JTAC_45 : C_JTAC {}; class C_JTAC_46 : C_JTAC {}; class C_JTAC_47 : C_JTAC {}; class C_JTAC_48 : C_JTAC {}; class C_JTAC_49 : C_JTAC {}; class C_JTAC_50 : C_JTAC {};
-// ====================================================================================
+
 class C_FM {        // "FM"        | FLIGHT MEDIC OR PLATOON MEDIC
     uniform         = "rhs_uniform_cu_ocp_1stcav";
     vest            = "rhsusf_iotv_ocp_Medic";
@@ -905,7 +731,7 @@ class C_FM {        // "FM"        | FLIGHT MEDIC OR PLATOON MEDIC
         _QUA15(ACE_epinephrine),	
         _QUA25(ACE_packingBandage),
         _QUA25(ACE_elasticBandage),	
-        _QUA25(ACE_FieldDressing),
+        _QUA25(ACE_packingBandage),
         _QUA25(ACE_quikclot),	
         _QUA4(ACE_salineIV),
         _QUA2(ACE_salineIV_500)				
@@ -918,7 +744,7 @@ class C_FM {        // "FM"        | FLIGHT MEDIC OR PLATOON MEDIC
     watch           = "tf_microdagr";
 };
 class C_FM_1 : C_FM {}; class C_FM_2 : C_FM {}; class C_FM_3 : C_FM {}; class C_FM_4 : C_FM {}; class C_FM_5 : C_FM {}; class C_FM_6 : C_FM {}; class C_FM_7 : C_FM {}; class C_FM_8 : C_FM {}; class C_FM_9 : C_FM {}; class C_FM_10 : C_FM {}; class C_FM_11 : C_FM {}; class C_FM_12 : C_FM {}; class C_FM_13 : C_FM {}; class C_FM_14 : C_FM {}; class C_FM_15 : C_FM {}; class C_FM_16 : C_FM {}; class C_FM_17 : C_FM {}; class C_FM_18 : C_FM {}; class C_FM_19 : C_FM {}; class C_FM_20 : C_FM {}; class C_FM_21 : C_FM {}; class C_FM_22 : C_FM {}; class C_FM_23 : C_FM {}; class C_FM_24 : C_FM {}; class C_FM_25 : C_FM {}; class C_FM_26 : C_FM {}; class C_FM_27 : C_FM {}; class C_FM_28 : C_FM {}; class C_FM_29 : C_FM {}; class C_FM_30 : C_FM {}; class C_FM_31 : C_FM {}; class C_FM_32 : C_FM {}; class C_FM_33 : C_FM {}; class C_FM_34 : C_FM {}; class C_FM_35 : C_FM {}; class C_FM_36 : C_FM {}; class C_FM_37 : C_FM {}; class C_FM_38 : C_FM {}; class C_FM_39 : C_FM {}; class C_FM_40 : C_FM {}; class C_FM_41 : C_FM {}; class C_FM_42 : C_FM {}; class C_FM_43 : C_FM {}; class C_FM_44 : C_FM {}; class C_FM_45 : C_FM {}; class C_FM_46 : C_FM {}; class C_FM_47 : C_FM {}; class C_FM_48 : C_FM {}; class C_FM_49 : C_FM {}; class C_FM_50 : C_FM {};
-// ====================================================================================
+
 class C_MTL {       // "MTL"       | MEDICAL TEAM LEADER
     uniform         = "rhs_uniform_cu_ocp_1stcav";
     vest            = "rhsusf_iotv_ocp_Medic";
@@ -939,7 +765,7 @@ class C_MTL {       // "MTL"       | MEDICAL TEAM LEADER
     items[] = {};
     magazines[] = {};
     addItemsToUniform[] = {
-        _QUA10(ACE_FieldDressing),
+        _QUA10(ACE_packingBandage),
         _QUA2(ACE_morphine),
         _QUA2(ACE_epinephrine),
         _QUA1(ACE_tourniquet),
@@ -977,8 +803,7 @@ class C_MTL {       // "MTL"       | MEDICAL TEAM LEADER
         _QUA5(ACE_epinephrine),	
         _QUA10(ACE_packingBandage),
         _QUA10(ACE_elasticBandage),	
-        _QUA10(ACE_FieldDressing),
-        _QUA10(ACE_quikclot),	
+        _QUA10(ACE_packingBandage),
         _QUA5(ACE_personalAidKit),
         _QUA2(Chemlight_Blue),
         _QUA2(Chemlight_Red)						
@@ -991,65 +816,7 @@ class C_MTL {       // "MTL"       | MEDICAL TEAM LEADER
     watch           = "tf_microdagr";
 };
 class C_MTL_1 : C_MTL {}; class C_MTL_2 : C_MTL {}; class C_MTL_3 : C_MTL {}; class C_MTL_4 : C_MTL {}; class C_MTL_5 : C_MTL {}; class C_MTL_6 : C_MTL {}; class C_MTL_7 : C_MTL {}; class C_MTL_8 : C_MTL {}; class C_MTL_9 : C_MTL {}; class C_MTL_10 : C_MTL {}; class C_MTL_11 : C_MTL {}; class C_MTL_12 : C_MTL {}; class C_MTL_13 : C_MTL {}; class C_MTL_14 : C_MTL {}; class C_MTL_15 : C_MTL {}; class C_MTL_16 : C_MTL {}; class C_MTL_17 : C_MTL {}; class C_MTL_18 : C_MTL {}; class C_MTL_19 : C_MTL {}; class C_MTL_20 : C_MTL {}; class C_MTL_21 : C_MTL {}; class C_MTL_22 : C_MTL {}; class C_MTL_23 : C_MTL {}; class C_MTL_24 : C_MTL {}; class C_MTL_25 : C_MTL {}; class C_MTL_26 : C_MTL {}; class C_MTL_27 : C_MTL {}; class C_MTL_28 : C_MTL {}; class C_MTL_29 : C_MTL {}; class C_MTL_30 : C_MTL {}; class C_MTL_31 : C_MTL {}; class C_MTL_32 : C_MTL {}; class C_MTL_33 : C_MTL {}; class C_MTL_34 : C_MTL {}; class C_MTL_35 : C_MTL {}; class C_MTL_36 : C_MTL {}; class C_MTL_37 : C_MTL {}; class C_MTL_38 : C_MTL {}; class C_MTL_39 : C_MTL {}; class C_MTL_40 : C_MTL {}; class C_MTL_41 : C_MTL {}; class C_MTL_42 : C_MTL {}; class C_MTL_43 : C_MTL {}; class C_MTL_44 : C_MTL {}; class C_MTL_45 : C_MTL {}; class C_MTL_46 : C_MTL {}; class C_MTL_47 : C_MTL {}; class C_MTL_48 : C_MTL {}; class C_MTL_49 : C_MTL {}; class C_MTL_50 : C_MTL {};
-// ====================================================================================
-class C_TC {       // "TC"        | TANK COMMANDER
-    uniform         = "rhs_uniform_cu_ocp_1stcav";
-    vest            = "rhsusf_iotv_ocp_Rifleman";
-    headgear        = "H_HelmetCrew_I";
-    goggles         = "rhs_ess_black";
-    nvgoggles       = "rhsusf_ANPVS_14";
-    backpack        = "rhsusf_assault_eagleaiii_ocp";
-    
-    primaryWeapon   = _WEAPON_PRIMARY0;
-    primaryWeaponAttachments[] = {
-        "acc_pointer_IR",
-        "RH_ta31rmr_2D"
-    };
-    
-    secondaryWeapon = "";
-    handgunWeapon = "";
-    
-    items[] = {};
-    magazines[] = {};
-    addItemsToUniform[] = {
-        _QUA10(ACE_FieldDressing),
-        _QUA2(ACE_morphine),
-        _QUA2(ACE_epinephrine),
-        _QUA1(ACE_tourniquet),
-        
-        _QUA2(ACE_CableTie),
-        
-        //_QUA1(_ITEM_RADIO1),
-        //_QUA1(_ITEM_RADIOADD),
-        
-        _QUA1(ACE_EarPlugs),
-        _QUA1(ACE_Flashlight_MX991),
-        _QUA1(ACE_DAGR),
-        _QUA1(ACE_MapTools),
-        _QUA1(ACE_IR_Strobe_Item),
-        _QUA2(_GRENADE)							
-    };
-    addItemsToVest[] = {
-        _QUA4(_MAG_PRIMARY),
-        _QUA2(_GRENADE),	
-        _QUA4(_GRENADE_SMOKE)							
-    };
-    addItemsToBackpack[] = {
-        _QUA2(_GRENADE),	
-        _QUA4(_GRENADE_SMOKE),	
-        _QUA2(Chemlight_Blue),
-        _QUA2(Chemlight_Red),	
-        _QUA1(Toolkit)						
-    };
-    
-    binoculars      = "";
-    map             = "ItemMap";
-    gps             = "ItemAndroid";
-    compass         = "ItemCompass";
-    watch           = "tf_microdagr";
-};
-class C_TC_1 : C_TC {}; class C_TC_2 : C_TC {}; class C_TC_3 : C_TC {}; class C_TC_4 : C_TC {}; class C_TC_5 : C_TC {}; class C_TC_6 : C_TC {}; class C_TC_7 : C_TC {}; class C_TC_8 : C_TC {}; class C_TC_9 : C_TC {}; class C_TC_10 : C_TC {}; class C_TC_11 : C_TC {}; class C_TC_12 : C_TC {}; class C_TC_13 : C_TC {}; class C_TC_14 : C_TC {}; class C_TC_15 : C_TC {}; class C_TC_16 : C_TC {}; class C_TC_17 : C_TC {}; class C_TC_18 : C_TC {}; class C_TC_19 : C_TC {}; class C_TC_20 : C_TC {}; class C_TC_21 : C_TC {}; class C_TC_22 : C_TC {}; class C_TC_23 : C_TC {}; class C_TC_24 : C_TC {}; class C_TC_25 : C_TC {}; class C_TC_26 : C_TC {}; class C_TC_27 : C_TC {}; class C_TC_28 : C_TC {}; class C_TC_29 : C_TC {}; class C_TC_30 : C_TC {}; class C_TC_31 : C_TC {}; class C_TC_32 : C_TC {}; class C_TC_33 : C_TC {}; class C_TC_34 : C_TC {}; class C_TC_35 : C_TC {}; class C_TC_36 : C_TC {}; class C_TC_37 : C_TC {}; class C_TC_38 : C_TC {}; class C_TC_39 : C_TC {}; class C_TC_40 : C_TC {}; class C_TC_41 : C_TC {}; class C_TC_42 : C_TC {}; class C_TC_43 : C_TC {}; class C_TC_44 : C_TC {}; class C_TC_45 : C_TC {}; class C_TC_46 : C_TC {}; class C_TC_47 : C_TC {}; class C_TC_48 : C_TC {}; class C_TC_49 : C_TC {}; class C_TC_50 : C_TC {};
-// ====================================================================================
+
 class C_OFF {                // "OFF"       | OFFICER
     uniform         = "rhs_uniform_cu_ocp_1stcav";
     vest            = "rhsusf_iotv_ocp_Squadleader";
@@ -1070,7 +837,7 @@ class C_OFF {                // "OFF"       | OFFICER
     items[] = {};
     magazines[] = {};
     addItemsToUniform[] = {
-        _QUA10(ACE_FieldDressing),
+        _QUA10(ACE_packingBandage),
         _QUA2(ACE_morphine),
         _QUA2(ACE_epinephrine),
         _QUA1(ACE_tourniquet),
@@ -1115,62 +882,7 @@ class C_OFF {                // "OFF"       | OFFICER
     watch           = "tf_microdagr";
 };
 class C_OFF_1 : C_OFF {}; class C_OFF_2 : C_OFF {}; class C_OFF_3 : C_OFF {}; class C_OFF_4 : C_OFF {}; class C_OFF_5 : C_OFF {}; class C_OFF_6 : C_OFF {}; class C_OFF_7 : C_OFF {}; class C_OFF_8 : C_OFF {}; class C_OFF_9 : C_OFF {}; class C_OFF_10 : C_OFF {}; class C_OFF_11 : C_OFF {}; class C_OFF_12 : C_OFF {}; class C_OFF_13 : C_OFF {}; class C_OFF_14 : C_OFF {}; class C_OFF_15 : C_OFF {}; class C_OFF_16 : C_OFF {}; class C_OFF_17 : C_OFF {}; class C_OFF_18 : C_OFF {}; class C_OFF_19 : C_OFF {}; class C_OFF_20 : C_OFF {}; class C_OFF_21 : C_OFF {}; class C_OFF_22 : C_OFF {}; class C_OFF_23 : C_OFF {}; class C_OFF_24 : C_OFF {}; class C_OFF_25 : C_OFF {}; class C_OFF_26 : C_OFF {}; class C_OFF_27 : C_OFF {}; class C_OFF_28 : C_OFF {}; class C_OFF_29 : C_OFF {}; class C_OFF_30 : C_OFF {}; class C_OFF_31 : C_OFF {}; class C_OFF_32 : C_OFF {}; class C_OFF_33 : C_OFF {}; class C_OFF_34 : C_OFF {}; class C_OFF_35 : C_OFF {}; class C_OFF_36 : C_OFF {}; class C_OFF_37 : C_OFF {}; class C_OFF_38 : C_OFF {}; class C_OFF_39 : C_OFF {}; class C_OFF_40 : C_OFF {}; class C_OFF_41 : C_OFF {}; class C_OFF_42 : C_OFF {}; class C_OFF_43 : C_OFF {}; class C_OFF_44 : C_OFF {}; class C_OFF_45 : C_OFF {}; class C_OFF_46 : C_OFF {}; class C_OFF_47 : C_OFF {}; class C_OFF_48 : C_OFF {}; class C_OFF_49 : C_OFF {}; class C_OFF_50 : C_OFF {};
-// ====================================================================================
-class C_ATM {     // "ATM"       | ANTI-TANK MAAWS
-    uniform         = "rhs_uniform_cu_ocp_1stcav";
-    vest            = "rhsusf_iotv_ocp_Rifleman";
-    headgear        = "rhsusf_ach_helmet_ocp";
-    goggles         = "rhs_googles_clear";
-    nvgoggles       = "rhsusf_ANPVS_14";
-    backpack        = "rhsusf_assault_eagleaiii_ocp";
-    
-    primaryWeapon   = _WEAPON_PRIMARY0;
-    primaryWeaponAttachments[] = {
-        "acc_pointer_IR",
-        "RH_ta31rmr_2D"
-    };
-    
-    secondaryWeapon = _WEAPON_LAUNCHER3;
-    handgunWeapon = "";
-    
-    items[] = {};
-    magazines[] = {};
-    addItemsToUniform[] = {
-        _QUA10(ACE_FieldDressing),
-        _QUA2(ACE_morphine),
-        _QUA2(ACE_epinephrine),
-        _QUA1(ACE_tourniquet),
-        
-        _QUA2(ACE_CableTie),
-        
-        //_QUA1(_ITEM_RADIO1),
-        //_QUA1(_ITEM_RADIOADD),
-        
-        _QUA1(ACE_EarPlugs),
-        _QUA1(ACE_Flashlight_MX991),
-        _QUA1(ACE_DAGR),
-        _QUA1(ACE_MapTools),
-        _QUA1(ACE_IR_Strobe_Item),
-        _QUA2(_GRENADE)							
-    };
-    addItemsToVest[] = {
-        _QUA6(_MAG_PRIMARY),
-        _QUA2(_GRENADE),	
-        _QUA4(_GRENADE_SMOKE)							
-    };
-    addItemsToBackpack[] = {
-        _QUA1(_MAG_LAUNCHER2),
-        _QUA1(_MAG_LAUNCHER3)						
-    };
-    
-    binoculars      = "";
-    map             = "ItemMap";
-    gps             = "";
-    compass         = "ItemCompass";
-    watch           = "tf_microdagr";
-};
-class C_ATM_1 : C_ATM {}; class C_ATM_2 : C_ATM {}; class C_ATM_3 : C_ATM {}; class C_ATM_4 : C_ATM {}; class C_ATM_5 : C_ATM {}; class C_ATM_6 : C_ATM {}; class C_ATM_7 : C_ATM {}; class C_ATM_8 : C_ATM {}; class C_ATM_9 : C_ATM {}; class C_ATM_10 : C_ATM {}; class C_ATM_11 : C_ATM {}; class C_ATM_12 : C_ATM {}; class C_ATM_13 : C_ATM {}; class C_ATM_14 : C_ATM {}; class C_ATM_15 : C_ATM {}; class C_ATM_16 : C_ATM {}; class C_ATM_17 : C_ATM {}; class C_ATM_18 : C_ATM {}; class C_ATM_19 : C_ATM {}; class C_ATM_20 : C_ATM {}; class C_ATM_21 : C_ATM {}; class C_ATM_22 : C_ATM {}; class C_ATM_23 : C_ATM {}; class C_ATM_24 : C_ATM {}; class C_ATM_25 : C_ATM {}; class C_ATM_26 : C_ATM {}; class C_ATM_27 : C_ATM {}; class C_ATM_28 : C_ATM {}; class C_ATM_29 : C_ATM {}; class C_ATM_30 : C_ATM {}; class C_ATM_31 : C_ATM {}; class C_ATM_32 : C_ATM {}; class C_ATM_33 : C_ATM {}; class C_ATM_34 : C_ATM {}; class C_ATM_35 : C_ATM {}; class C_ATM_36 : C_ATM {}; class C_ATM_37 : C_ATM {}; class C_ATM_38 : C_ATM {}; class C_ATM_39 : C_ATM {}; class C_ATM_40 : C_ATM {}; class C_ATM_41 : C_ATM {}; class C_ATM_42 : C_ATM {}; class C_ATM_43 : C_ATM {}; class C_ATM_44 : C_ATM {}; class C_ATM_45 : C_ATM {}; class C_ATM_46 : C_ATM {}; class C_ATM_47 : C_ATM {}; class C_ATM_48 : C_ATM {}; class C_ATM_49 : C_ATM {}; class C_ATM_50 : C_ATM {};
-// ====================================================================================
+
 class C_FO {           // "FO"        | FORWARD OBSERVER
     uniform         = "rhs_uniform_cu_ocp_1stcav";
     vest            = "rhsusf_iotv_ocp_Squadleader";
@@ -1191,7 +903,7 @@ class C_FO {           // "FO"        | FORWARD OBSERVER
     items[] = {};
     magazines[] = {};
     addItemsToUniform[] = {
-        _QUA10(ACE_FieldDressing),
+        _QUA10(ACE_packingBandage),
         _QUA2(ACE_morphine),
         _QUA2(ACE_epinephrine),
         _QUA1(ACE_tourniquet),
@@ -1236,7 +948,7 @@ class C_FO {           // "FO"        | FORWARD OBSERVER
     watch           = "tf_microdagr";
 };
 class C_FO_1 : C_FO {}; class C_FO_2 : C_FO {}; class C_FO_3 : C_FO {}; class C_FO_4 : C_FO {}; class C_FO_5 : C_FO {}; class C_FO_6 : C_FO {}; class C_FO_7 : C_FO {}; class C_FO_8 : C_FO {}; class C_FO_9 : C_FO {}; class C_FO_10 : C_FO {}; class C_FO_11 : C_FO {}; class C_FO_12 : C_FO {}; class C_FO_13 : C_FO {}; class C_FO_14 : C_FO {}; class C_FO_15 : C_FO {}; class C_FO_16 : C_FO {}; class C_FO_17 : C_FO {}; class C_FO_18 : C_FO {}; class C_FO_19 : C_FO {}; class C_FO_20 : C_FO {}; class C_FO_21 : C_FO {}; class C_FO_22 : C_FO {}; class C_FO_23 : C_FO {}; class C_FO_24 : C_FO {}; class C_FO_25 : C_FO {}; class C_FO_26 : C_FO {}; class C_FO_27 : C_FO {}; class C_FO_28 : C_FO {}; class C_FO_29 : C_FO {}; class C_FO_30 : C_FO {}; class C_FO_31 : C_FO {}; class C_FO_32 : C_FO {}; class C_FO_33 : C_FO {}; class C_FO_34 : C_FO {}; class C_FO_35 : C_FO {}; class C_FO_36 : C_FO {}; class C_FO_37 : C_FO {}; class C_FO_38 : C_FO {}; class C_FO_39 : C_FO {}; class C_FO_40 : C_FO {}; class C_FO_41 : C_FO {}; class C_FO_42 : C_FO {}; class C_FO_43 : C_FO {}; class C_FO_44 : C_FO {}; class C_FO_45 : C_FO {}; class C_FO_46 : C_FO {}; class C_FO_47 : C_FO {}; class C_FO_48 : C_FO {}; class C_FO_49 : C_FO {}; class C_FO_50 : C_FO {};
-// ====================================================================================
+
 class C_ENGSL {         // "ENGSL"     | ENGINEER SL
     uniform         = "rhs_uniform_cu_ocp_1stcav";
     vest            = "rhsusf_iotv_ocp_Repair";
@@ -1257,7 +969,7 @@ class C_ENGSL {         // "ENGSL"     | ENGINEER SL
     items[] = {};
     magazines[] = {};
     addItemsToUniform[] = {
-        _QUA10(ACE_FieldDressing),
+        _QUA10(ACE_packingBandage),
         _QUA2(ACE_morphine),
         _QUA2(ACE_epinephrine),
         _QUA1(ACE_tourniquet),
@@ -1295,3 +1007,236 @@ class C_ENGSL {         // "ENGSL"     | ENGINEER SL
     watch           = "tf_microdagr";
 };
 class C_ENGSL_1 : C_ENGSL {}; class C_ENGSL_2 : C_ENGSL {}; class C_ENGSL_3 : C_ENGSL {}; class C_ENGSL_4 : C_ENGSL {}; class C_ENGSL_5 : C_ENGSL {}; class C_ENGSL_6 : C_ENGSL {}; class C_ENGSL_7 : C_ENGSL {}; class C_ENGSL_8 : C_ENGSL {}; class C_ENGSL_9 : C_ENGSL {}; class C_ENGSL_10 : C_ENGSL {}; class C_ENGSL_11 : C_ENGSL {}; class C_ENGSL_12 : C_ENGSL {}; class C_ENGSL_13 : C_ENGSL {}; class C_ENGSL_14 : C_ENGSL {}; class C_ENGSL_15 : C_ENGSL {}; class C_ENGSL_16 : C_ENGSL {}; class C_ENGSL_17 : C_ENGSL {}; class C_ENGSL_18 : C_ENGSL {}; class C_ENGSL_19 : C_ENGSL {}; class C_ENGSL_20 : C_ENGSL {}; class C_ENGSL_21 : C_ENGSL {}; class C_ENGSL_22 : C_ENGSL {}; class C_ENGSL_23 : C_ENGSL {}; class C_ENGSL_24 : C_ENGSL {}; class C_ENGSL_25 : C_ENGSL {}; class C_ENGSL_26 : C_ENGSL {}; class C_ENGSL_27 : C_ENGSL {}; class C_ENGSL_28 : C_ENGSL {}; class C_ENGSL_29 : C_ENGSL {}; class C_ENGSL_30 : C_ENGSL {}; class C_ENGSL_31 : C_ENGSL {}; class C_ENGSL_32 : C_ENGSL {}; class C_ENGSL_33 : C_ENGSL {}; class C_ENGSL_34 : C_ENGSL {}; class C_ENGSL_35 : C_ENGSL {}; class C_ENGSL_36 : C_ENGSL {}; class C_ENGSL_37 : C_ENGSL {}; class C_ENGSL_38 : C_ENGSL {}; class C_ENGSL_39 : C_ENGSL {}; class C_ENGSL_40 : C_ENGSL {}; class C_ENGSL_41 : C_ENGSL {}; class C_ENGSL_42 : C_ENGSL {}; class C_ENGSL_43 : C_ENGSL {}; class C_ENGSL_44 : C_ENGSL {}; class C_ENGSL_45 : C_ENGSL {}; class C_ENGSL_46 : C_ENGSL {}; class C_ENGSL_47 : C_ENGSL {}; class C_ENGSL_48 : C_ENGSL {}; class C_ENGSL_49 : C_ENGSL {}; class C_ENGSL_50 : C_ENGSL {};
+
+
+
+class C_AT {               // "AT"        | ANTI-TANK JAV
+    uniform         = "rhs_uniform_cu_ocp_1stcav";
+    vest            = "rhsusf_iotv_ocp_Rifleman";
+    headgear        = "rhsusf_ach_helmet_ocp";
+    goggles         = "rhs_googles_clear";
+    nvgoggles       = "rhsusf_ANPVS_14";
+    backpack        = "rhsusf_assault_eagleaiii_ocp";
+    
+    primaryWeapon   = _WEAPON_PRIMARY0;
+    primaryWeaponAttachments[] = {
+        "acc_pointer_IR",
+        "RH_ta31rmr_2D"
+    };
+    
+    secondaryWeapon = _WEAPON_LAUNCHER0;
+    handgunWeapon = "";
+    
+    items[] = {};
+    magazines[] = {};
+    addItemsToUniform[] = {
+        _QUA10(ACE_packingBandage),
+        _QUA2(ACE_morphine),
+        _QUA2(ACE_epinephrine),
+        _QUA1(ACE_tourniquet),
+        
+        _QUA2(ACE_CableTie),
+        
+        //_QUA1(_ITEM_RADIO1),
+        //_QUA1(_ITEM_RADIOADD),
+        
+        _QUA1(ACE_EarPlugs),
+        _QUA1(ACE_Flashlight_MX991),
+        _QUA1(ACE_DAGR),
+        _QUA1(ACE_MapTools),
+        _QUA1(ACE_IR_Strobe_Item),
+        _QUA2(_GRENADE)							
+    };
+    addItemsToVest[] = {
+        _QUA6(_MAG_PRIMARY),
+        _QUA2(_GRENADE),	
+        _QUA4(_GRENADE_SMOKE)							
+    };
+    addItemsToBackpack[] = {
+        _QUA2(_MAG_PRIMARY),
+        _QUA2(_GRENADE),	
+        _QUA4(_GRENADE_SMOKE),	
+        _QUA2(Chemlight_Blue),
+        _QUA2(Chemlight_Red),
+        _QUA1(_MAG_LAUNCHER0)						
+    };
+    
+    binoculars      = "";
+    map             = "ItemMap";
+    gps             = "";
+    compass         = "ItemCompass";
+    watch           = "tf_microdagr";
+};
+class C_AT_1 : C_AT {}; class C_AT_2 : C_AT {}; class C_AT_3 : C_AT {}; class C_AT_4 : C_AT {}; class C_AT_5 : C_AT {}; class C_AT_6 : C_AT {}; class C_AT_7 : C_AT {}; class C_AT_8 : C_AT {}; class C_AT_9 : C_AT {}; class C_AT_10 : C_AT {}; class C_AT_11 : C_AT {}; class C_AT_12 : C_AT {}; class C_AT_13 : C_AT {}; class C_AT_14 : C_AT {}; class C_AT_15 : C_AT {}; class C_AT_16 : C_AT {}; class C_AT_17 : C_AT {}; class C_AT_18 : C_AT {}; class C_AT_19 : C_AT {}; class C_AT_20 : C_AT {}; class C_AT_21 : C_AT {}; class C_AT_22 : C_AT {}; class C_AT_23 : C_AT {}; class C_AT_24 : C_AT {}; class C_AT_25 : C_AT {}; class C_AT_26 : C_AT {}; class C_AT_27 : C_AT {}; class C_AT_28 : C_AT {}; class C_AT_29 : C_AT {}; class C_AT_30 : C_AT {}; class C_AT_31 : C_AT {}; class C_AT_32 : C_AT {}; class C_AT_33 : C_AT {}; class C_AT_34 : C_AT {}; class C_AT_35 : C_AT {}; class C_AT_36 : C_AT {}; class C_AT_37 : C_AT {}; class C_AT_38 : C_AT {}; class C_AT_39 : C_AT {}; class C_AT_40 : C_AT {}; class C_AT_41 : C_AT {}; class C_AT_42 : C_AT {}; class C_AT_43 : C_AT {}; class C_AT_44 : C_AT {}; class C_AT_45 : C_AT {}; class C_AT_46 : C_AT {}; class C_AT_47 : C_AT {}; class C_AT_48 : C_AT {}; class C_AT_49 : C_AT {}; class C_AT_50 : C_AT {};
+
+class C_ATM {     // "ATM"       | ANTI-TANK MAAWS
+    uniform         = "rhs_uniform_cu_ocp_1stcav";
+    vest            = "rhsusf_iotv_ocp_Rifleman";
+    headgear        = "rhsusf_ach_helmet_ocp";
+    goggles         = "rhs_googles_clear";
+    nvgoggles       = "rhsusf_ANPVS_14";
+    backpack        = "rhsusf_assault_eagleaiii_ocp";
+    
+    primaryWeapon   = _WEAPON_PRIMARY0;
+    primaryWeaponAttachments[] = {
+        "acc_pointer_IR",
+        "RH_ta31rmr_2D"
+    };
+    
+    secondaryWeapon = _WEAPON_LAUNCHER3;
+    handgunWeapon = "";
+    
+    items[] = {};
+    magazines[] = {};
+    addItemsToUniform[] = {
+        _QUA10(ACE_packingBandage),
+        _QUA2(ACE_morphine),
+        _QUA2(ACE_epinephrine),
+        _QUA1(ACE_tourniquet),
+        
+        _QUA2(ACE_CableTie),
+        
+        //_QUA1(_ITEM_RADIO1),
+        //_QUA1(_ITEM_RADIOADD),
+        
+        _QUA1(ACE_EarPlugs),
+        _QUA1(ACE_Flashlight_MX991),
+        _QUA1(ACE_DAGR),
+        _QUA1(ACE_MapTools),
+        _QUA1(ACE_IR_Strobe_Item),
+        _QUA2(_GRENADE)							
+    };
+    addItemsToVest[] = {
+        _QUA6(_MAG_PRIMARY),
+        _QUA2(_GRENADE),	
+        _QUA4(_GRENADE_SMOKE)							
+    };
+    addItemsToBackpack[] = {
+        _QUA1(_MAG_LAUNCHER2),
+        _QUA1(_MAG_LAUNCHER3)						
+    };
+    
+    binoculars      = "";
+    map             = "ItemMap";
+    gps             = "";
+    compass         = "ItemCompass";
+    watch           = "tf_microdagr";
+};
+class C_ATM_1 : C_ATM {}; class C_ATM_2 : C_ATM {}; class C_ATM_3 : C_ATM {}; class C_ATM_4 : C_ATM {}; class C_ATM_5 : C_ATM {}; class C_ATM_6 : C_ATM {}; class C_ATM_7 : C_ATM {}; class C_ATM_8 : C_ATM {}; class C_ATM_9 : C_ATM {}; class C_ATM_10 : C_ATM {}; class C_ATM_11 : C_ATM {}; class C_ATM_12 : C_ATM {}; class C_ATM_13 : C_ATM {}; class C_ATM_14 : C_ATM {}; class C_ATM_15 : C_ATM {}; class C_ATM_16 : C_ATM {}; class C_ATM_17 : C_ATM {}; class C_ATM_18 : C_ATM {}; class C_ATM_19 : C_ATM {}; class C_ATM_20 : C_ATM {}; class C_ATM_21 : C_ATM {}; class C_ATM_22 : C_ATM {}; class C_ATM_23 : C_ATM {}; class C_ATM_24 : C_ATM {}; class C_ATM_25 : C_ATM {}; class C_ATM_26 : C_ATM {}; class C_ATM_27 : C_ATM {}; class C_ATM_28 : C_ATM {}; class C_ATM_29 : C_ATM {}; class C_ATM_30 : C_ATM {}; class C_ATM_31 : C_ATM {}; class C_ATM_32 : C_ATM {}; class C_ATM_33 : C_ATM {}; class C_ATM_34 : C_ATM {}; class C_ATM_35 : C_ATM {}; class C_ATM_36 : C_ATM {}; class C_ATM_37 : C_ATM {}; class C_ATM_38 : C_ATM {}; class C_ATM_39 : C_ATM {}; class C_ATM_40 : C_ATM {}; class C_ATM_41 : C_ATM {}; class C_ATM_42 : C_ATM {}; class C_ATM_43 : C_ATM {}; class C_ATM_44 : C_ATM {}; class C_ATM_45 : C_ATM {}; class C_ATM_46 : C_ATM {}; class C_ATM_47 : C_ATM {}; class C_ATM_48 : C_ATM {}; class C_ATM_49 : C_ATM {}; class C_ATM_50 : C_ATM {};
+
+class C_ATL {            // "ATL"       | LIGHT ANTI-TANK
+    uniform         = "rhs_uniform_cu_ocp_1stcav";
+    vest            = "rhsusf_iotv_ocp_Rifleman";
+    headgear        = "rhsusf_ach_helmet_ocp";
+    goggles         = "rhs_googles_clear";
+    nvgoggles       = "rhsusf_ANPVS_14";
+    backpack        = "rhsusf_assault_eagleaiii_ocp";
+    
+    primaryWeapon   = _WEAPON_PRIMARY0;
+    primaryWeaponAttachments[] = {
+        "acc_pointer_IR",
+        "RH_ta31rmr_2D"
+    };
+    
+    secondaryWeapon = _WEAPON_LAUNCHER2;
+    handgunWeapon = "";
+    
+    items[] = {};
+    magazines[] = {};
+    addItemsToUniform[] = {
+        _QUA10(ACE_packingBandage),
+        _QUA2(ACE_morphine),
+        _QUA2(ACE_epinephrine),
+        _QUA1(ACE_tourniquet),
+        
+        _QUA2(ACE_CableTie),
+        
+        //_QUA1(_ITEM_RADIO1),
+        //_QUA1(_ITEM_RADIOADD),
+        
+        _QUA1(ACE_EarPlugs),
+        _QUA1(ACE_Flashlight_MX991),
+        _QUA1(ACE_DAGR),
+        _QUA1(ACE_MapTools),
+        _QUA1(ACE_IR_Strobe_Item),
+        _QUA2(_GRENADE)							
+    };
+    addItemsToVest[] = {
+        _QUA4(_MAG_PRIMARY),
+        _QUA2(_GRENADE),	
+        _QUA4(_GRENADE_SMOKE)							
+    };
+    addItemsToBackpack[] = {
+        _QUA4(_MAG_PRIMARY),
+        _QUA2(_GRENADE),	
+        _QUA4(_GRENADE_SMOKE),	
+        _QUA2(Chemlight_Blue),
+        _QUA2(Chemlight_Red)						
+    };
+    
+    binoculars      = "";
+    map             = "ItemMap";
+    gps             = "";
+    compass         = "ItemCompass";
+    watch           = "tf_microdagr";
+};
+class C_ATL_1 : C_ATL {}; class C_ATL_2 : C_ATL {}; class C_ATL_3 : C_ATL {}; class C_ATL_4 : C_ATL {}; class C_ATL_5 : C_ATL {}; class C_ATL_6 : C_ATL {}; class C_ATL_7 : C_ATL {}; class C_ATL_8 : C_ATL {}; class C_ATL_9 : C_ATL {}; class C_ATL_10 : C_ATL {}; class C_ATL_11 : C_ATL {}; class C_ATL_12 : C_ATL {}; class C_ATL_13 : C_ATL {}; class C_ATL_14 : C_ATL {}; class C_ATL_15 : C_ATL {}; class C_ATL_16 : C_ATL {}; class C_ATL_17 : C_ATL {}; class C_ATL_18 : C_ATL {}; class C_ATL_19 : C_ATL {}; class C_ATL_20 : C_ATL {}; class C_ATL_21 : C_ATL {}; class C_ATL_22 : C_ATL {}; class C_ATL_23 : C_ATL {}; class C_ATL_24 : C_ATL {}; class C_ATL_25 : C_ATL {}; class C_ATL_26 : C_ATL {}; class C_ATL_27 : C_ATL {}; class C_ATL_28 : C_ATL {}; class C_ATL_29 : C_ATL {}; class C_ATL_30 : C_ATL {}; class C_ATL_31 : C_ATL {}; class C_ATL_32 : C_ATL {}; class C_ATL_33 : C_ATL {}; class C_ATL_34 : C_ATL {}; class C_ATL_35 : C_ATL {}; class C_ATL_36 : C_ATL {}; class C_ATL_37 : C_ATL {}; class C_ATL_38 : C_ATL {}; class C_ATL_39 : C_ATL {}; class C_ATL_40 : C_ATL {}; class C_ATL_41 : C_ATL {}; class C_ATL_42 : C_ATL {}; class C_ATL_43 : C_ATL {}; class C_ATL_44 : C_ATL {}; class C_ATL_45 : C_ATL {}; class C_ATL_46 : C_ATL {}; class C_ATL_47 : C_ATL {}; class C_ATL_48 : C_ATL {}; class C_ATL_49 : C_ATL {}; class C_ATL_50 : C_ATL {};
+
+class C_AA {             // "AA"        | ANTI-AIR
+    uniform         = "rhs_uniform_cu_ocp_1stcav";
+    vest            = "rhsusf_iotv_ocp_Rifleman";
+    headgear        = "rhsusf_ach_helmet_ocp";
+    goggles         = "rhs_googles_clear";
+    nvgoggles       = "rhsusf_ANPVS_14";
+    backpack        = "rhsusf_assault_eagleaiii_ocp";
+    
+    primaryWeapon   = _WEAPON_LAUNCHER1;
+    primaryWeaponAttachments[] = {
+        "acc_pointer_IR",
+        "RH_ta31rmr_2D"
+    };
+    
+    secondaryWeapon = _WEAPON_LAUNCHER1;
+    handgunWeapon = "";
+    
+    items[] = {};
+    magazines[] = {};
+    addItemsToUniform[] = {
+        _QUA10(ACE_packingBandage),
+        _QUA2(ACE_morphine),
+        _QUA2(ACE_epinephrine),
+        _QUA1(ACE_tourniquet),
+        
+        _QUA2(ACE_CableTie),
+        
+        //_QUA1(_ITEM_RADIO1),
+        //_QUA1(_ITEM_RADIOADD),
+        
+        _QUA1(ACE_EarPlugs),
+        _QUA1(ACE_Flashlight_MX991),
+        _QUA1(ACE_DAGR),
+        _QUA1(ACE_MapTools),
+        _QUA1(ACE_IR_Strobe_Item),
+        _QUA2(_GRENADE)							
+    };
+    addItemsToVest[] = {
+        _QUA6(_MAG_PRIMARY),
+        _QUA2(_GRENADE),	
+        _QUA4(_GRENADE_SMOKE)							
+    };
+    addItemsToBackpack[] = {
+        _QUA2(_MAG_PRIMARY),
+        _QUA2(_GRENADE),	
+        _QUA4(_GRENADE_SMOKE),	
+        _QUA2(Chemlight_Blue),
+        _QUA2(Chemlight_Red),
+        _QUA1(_MAG_LAUNCHER1)						
+    };
+    
+    binoculars      = "";
+    map             = "ItemMap";
+    gps             = "";
+    compass         = "ItemCompass";
+    watch           = "tf_microdagr";
+};
+class C_AA_1 : C_AA {}; class C_AA_2 : C_AA {}; class C_AA_3 : C_AA {}; class C_AA_4 : C_AA {}; class C_AA_5 : C_AA {}; class C_AA_6 : C_AA {}; class C_AA_7 : C_AA {}; class C_AA_8 : C_AA {}; class C_AA_9 : C_AA {}; class C_AA_10 : C_AA {}; class C_AA_11 : C_AA {}; class C_AA_12 : C_AA {}; class C_AA_13 : C_AA {}; class C_AA_14 : C_AA {}; class C_AA_15 : C_AA {}; class C_AA_16 : C_AA {}; class C_AA_17 : C_AA {}; class C_AA_18 : C_AA {}; class C_AA_19 : C_AA {}; class C_AA_20 : C_AA {}; class C_AA_21 : C_AA {}; class C_AA_22 : C_AA {}; class C_AA_23 : C_AA {}; class C_AA_24 : C_AA {}; class C_AA_25 : C_AA {}; class C_AA_26 : C_AA {}; class C_AA_27 : C_AA {}; class C_AA_28 : C_AA {}; class C_AA_29 : C_AA {}; class C_AA_30 : C_AA {}; class C_AA_31 : C_AA {}; class C_AA_32 : C_AA {}; class C_AA_33 : C_AA {}; class C_AA_34 : C_AA {}; class C_AA_35 : C_AA {}; class C_AA_36 : C_AA {}; class C_AA_37 : C_AA {}; class C_AA_38 : C_AA {}; class C_AA_39 : C_AA {}; class C_AA_40 : C_AA {}; class C_AA_41 : C_AA {}; class C_AA_42 : C_AA {}; class C_AA_43 : C_AA {}; class C_AA_44 : C_AA {}; class C_AA_45 : C_AA {}; class C_AA_46 : C_AA {}; class C_AA_47 : C_AA {}; class C_AA_48 : C_AA {}; class C_AA_49 : C_AA {}; class C_AA_50 : C_AA {};

--- a/cScripts/Loadouts/loadout_Crew.hpp
+++ b/cScripts/Loadouts/loadout_Crew.hpp
@@ -1,18 +1,17 @@
 /*
-GearVersionDate: 160303
+GearVersionDate: 160413
 */
 class C_C {             // "C"          | CREWMAN
     uniform         = "rhs_uniform_cu_ocp_1stcav";
     vest            = "rhsusf_iotv_ocp_Rifleman";
     headgear        = "H_HelmetCrew_I";
     goggles         = "rhs_ess_black";
-    nvgoggles       = "rhsusf_ANPVS_14";
+    nvgoggles       = "rhsusf_ANPVS_15";
     backpack        = "rhsusf_assault_eagleaiii_ocp";
     
     primaryWeapon   = _WEAPON_PRIMARY0;
     primaryWeaponAttachments[] = {
-        "acc_pointer_IR",
-        "RH_ta31rmr_2D"
+        "acc_pointer_IR"
     };
     
     secondaryWeapon = "";
@@ -21,7 +20,7 @@ class C_C {             // "C"          | CREWMAN
     items[] = {};
     magazines[] = {};
     addItemsToUniform[] = {
-        _QUA10(ACE_FieldDressing),
+        _QUA10(ACE_packingBandage),
         _QUA2(ACE_morphine),
         _QUA2(ACE_epinephrine),
         _QUA1(ACE_tourniquet),
@@ -46,24 +45,88 @@ class C_C {             // "C"          | CREWMAN
     addItemsToBackpack[] = {
         _QUA2(_GRENADE),	
         _QUA4(_GRENADE_SMOKE),	
+        _QUA4(_GRENADE_SMOKE_GREEN),	
+        _QUA4(_GRENADE_SMOKE_YELLOW),	
+        _QUA2(Chemlight_Blue),
+        _QUA2(Chemlight_Red),
+        _QUA1(Toolkit)						
+    };
+    
+    binoculars      = "Binocular";
+    map             = "ItemMap";
+    gps             = "ItemAndroid";
+    compass         = "ItemCompass";
+    watch           = "tf_microdagr";
+};
+class C_C_1 : C_C {}; class C_C_2 : C_C {}; class C_C_3 : C_C {}; class C_C_4 : C_C {}; class C_C_5 : C_C {}; class C_C_6 : C_C {}; class C_C_7 : C_C {}; class C_C_8 : C_C {}; class C_C_9 : C_C {}; class C_C_10 : C_C {}; class C_C_11 : C_C {}; class C_C_12 : C_C {}; class C_C_13 : C_C {}; class C_C_14 : C_C {}; class C_C_15 : C_C {}; class C_C_16 : C_C {}; class C_C_17 : C_C {}; class C_C_18 : C_C {}; class C_C_19 : C_C {}; class C_C_20 : C_C {}; class C_C_21 : C_C {}; class C_C_22 : C_C {}; class C_C_23 : C_C {}; class C_C_24 : C_C {}; class C_C_25 : C_C {}; class C_C_26 : C_C {}; class C_C_27 : C_C {}; class C_C_28 : C_C {}; class C_C_29 : C_C {}; class C_C_30 : C_C {}; class C_C_31 : C_C {}; class C_C_32 : C_C {}; class C_C_33 : C_C {}; class C_C_34 : C_C {}; class C_C_35 : C_C {}; class C_C_36 : C_C {}; class C_C_37 : C_C {}; class C_C_38 : C_C {}; class C_C_39 : C_C {}; class C_C_40 : C_C {}; class C_C_41 : C_C {}; class C_C_42 : C_C {}; class C_C_43 : C_C {}; class C_C_44 : C_C {}; class C_C_45 : C_C {}; class C_C_46 : C_C {}; class C_C_47 : C_C {}; class C_C_48 : C_C {}; class C_C_49 : C_C {}; class C_C_50 : C_C {};
+
+class C_TC {       // "TC"        | TANK COMMANDER
+    uniform         = "rhs_uniform_cu_ocp_1stcav";
+    vest            = "rhsusf_iotv_ocp_Grenadier";
+    headgear        = "H_HelmetCrew_I";
+    goggles         = "rhs_ess_black";
+    nvgoggles       = "rhsusf_ANPVS_15";
+    backpack        = "rhsusf_assault_eagleaiii_ocp";
+    
+    primaryWeapon   = _WEAPON_PRIMARY_GL0;
+    primaryWeaponAttachments[] = {
+        acc_pointer_IR
+    };
+    
+    secondaryWeapon = "";
+    handgunWeapon = "";
+    
+    items[] = {};
+    magazines[] = {};
+    addItemsToUniform[] = {
+        _QUA10(ACE_packingBandage),
+        _QUA2(ACE_morphine),
+        _QUA2(ACE_epinephrine),
+        _QUA1(ACE_tourniquet),
+        
+        _QUA2(ACE_CableTie),
+        
+        //_QUA1(_ITEM_RADIO1),
+        //_QUA1(_ITEM_RADIOADD),
+        
+        _QUA1(ACE_EarPlugs),
+        _QUA1(ACE_Flashlight_MX991),
+        _QUA1(ACE_microDAGR),
+        _QUA1(ACE_MapTools),
+        _QUA1(ACE_IR_Strobe_Item),
+        _QUA2(_GRENADE)							
+    };
+    addItemsToVest[] = {
+        _QUA4(_MAG_PRIMARY),
+        _QUA2(_GRENADE),	
+        _QUA4(_GRENADE_SMOKE),
+        _QUA4(_GLSHELL0),	
+        _QUA4(_GLSHELL1),	
+        _QUA4(_GLSHELLSMOKE)			
+    };
+    addItemsToBackpack[] = {
+        _QUA2(_GRENADE),	
+        _QUA4(_GRENADE_SMOKE),	
+        _QUA2(_GLSHELLSMOKEGREEN),	
+        _QUA2(_GLSHELLSMOKEYELLOW),	
         _QUA2(Chemlight_Blue),
         _QUA2(Chemlight_Red),	
         _QUA1(Toolkit)						
     };
     
-    binoculars      = "";
+    binoculars      = "ACE_Vector";
     map             = "ItemMap";
-    gps             = "";
+    gps             = "ItemAndroid";
     compass         = "ItemCompass";
     watch           = "tf_microdagr";
 };
-class C_C_1 : C_C {}; class C_C_2 : C_C {}; class C_C_3 : C_C {}; class C_C_4 : C_C {}; class C_C_5 : C_C {}; class C_C_6 : C_C {}; class C_C_7 : C_C {}; class C_C_8 : C_C {}; class C_C_9 : C_C {}; class C_C_10 : C_C {}; class C_C_11 : C_C {}; class C_C_12 : C_C {}; class C_C_13 : C_C {}; class C_C_14 : C_C {}; class C_C_15 : C_C {}; class C_C_16 : C_C {}; class C_C_17 : C_C {}; class C_C_18 : C_C {}; class C_C_19 : C_C {}; class C_C_20 : C_C {}; class C_C_21 : C_C {}; class C_C_22 : C_C {}; class C_C_23 : C_C {}; class C_C_24 : C_C {}; class C_C_25 : C_C {}; class C_C_26 : C_C {}; class C_C_27 : C_C {}; class C_C_28 : C_C {}; class C_C_29 : C_C {}; class C_C_30 : C_C {}; class C_C_31 : C_C {}; class C_C_32 : C_C {}; class C_C_33 : C_C {}; class C_C_34 : C_C {}; class C_C_35 : C_C {}; class C_C_36 : C_C {}; class C_C_37 : C_C {}; class C_C_38 : C_C {}; class C_C_39 : C_C {}; class C_C_40 : C_C {}; class C_C_41 : C_C {}; class C_C_42 : C_C {}; class C_C_43 : C_C {}; class C_C_44 : C_C {}; class C_C_45 : C_C {}; class C_C_46 : C_C {}; class C_C_47 : C_C {}; class C_C_48 : C_C {}; class C_C_49 : C_C {}; class C_C_50 : C_C {};
-// ====================================================================================
+class C_TC_1 : C_TC {}; class C_TC_2 : C_TC {}; class C_TC_3 : C_TC {}; class C_TC_4 : C_TC {}; class C_TC_5 : C_TC {}; class C_TC_6 : C_TC {}; class C_TC_7 : C_TC {}; class C_TC_8 : C_TC {}; class C_TC_9 : C_TC {}; class C_TC_10 : C_TC {}; class C_TC_11 : C_TC {}; class C_TC_12 : C_TC {}; class C_TC_13 : C_TC {}; class C_TC_14 : C_TC {}; class C_TC_15 : C_TC {}; class C_TC_16 : C_TC {}; class C_TC_17 : C_TC {}; class C_TC_18 : C_TC {}; class C_TC_19 : C_TC {}; class C_TC_20 : C_TC {}; class C_TC_21 : C_TC {}; class C_TC_22 : C_TC {}; class C_TC_23 : C_TC {}; class C_TC_24 : C_TC {}; class C_TC_25 : C_TC {}; class C_TC_26 : C_TC {}; class C_TC_27 : C_TC {}; class C_TC_28 : C_TC {}; class C_TC_29 : C_TC {}; class C_TC_30 : C_TC {}; class C_TC_31 : C_TC {}; class C_TC_32 : C_TC {}; class C_TC_33 : C_TC {}; class C_TC_34 : C_TC {}; class C_TC_35 : C_TC {}; class C_TC_36 : C_TC {}; class C_TC_37 : C_TC {}; class C_TC_38 : C_TC {}; class C_TC_39 : C_TC {}; class C_TC_40 : C_TC {}; class C_TC_41 : C_TC {}; class C_TC_42 : C_TC {}; class C_TC_43 : C_TC {}; class C_TC_44 : C_TC {}; class C_TC_45 : C_TC {}; class C_TC_46 : C_TC {}; class C_TC_47 : C_TC {}; class C_TC_48 : C_TC {}; class C_TC_49 : C_TC {}; class C_TC_50 : C_TC {};
+
 class C_P {             // "P"          | HELICOPTER PILOT
     uniform         = "rhs_uniform_cu_ocp_1stcav";
     vest            = "rhsusf_iotv_ocp_Teamleader";
     headgear        = "H_PilotHelmetHeli_B";
-    nvgoggles       = rhsusf_ANPVS_15;
+    nvgoggles       = "rhsusf_ANPVS_15";
     backpack        = "";
     
     primaryWeapon   = _WEAPON_PRIMARY0;
@@ -78,7 +141,7 @@ class C_P {             // "P"          | HELICOPTER PILOT
     items[] = {};
     magazines[] = {};
     addItemsToUniform[] = {
-        _QUA10(ACE_FieldDressing),
+        _QUA10(ACE_packingBandage),
         _QUA2(ACE_morphine),
         _QUA2(ACE_epinephrine),
         _QUA1(ACE_tourniquet),
@@ -112,12 +175,12 @@ class C_P {             // "P"          | HELICOPTER PILOT
     watch           = "tf_microdagr";
 };
 class C_P_1 : C_P {}; class C_P_2 : C_P {}; class C_P_3 : C_P {}; class C_P_4 : C_P {}; class C_P_5 : C_P {}; class C_P_6 : C_P {}; class C_P_7 : C_P {}; class C_P_8 : C_P {}; class C_P_9 : C_P {}; class C_P_10 : C_P {}; class C_P_11 : C_P {}; class C_P_12 : C_P {}; class C_P_13 : C_P {}; class C_P_14 : C_P {}; class C_P_15 : C_P {}; class C_P_16 : C_P {}; class C_P_17 : C_P {}; class C_P_18 : C_P {}; class C_P_19 : C_P {}; class C_P_20 : C_P {}; class C_P_21 : C_P {}; class C_P_22 : C_P {}; class C_P_23 : C_P {}; class C_P_24 : C_P {}; class C_P_25 : C_P {}; class C_P_26 : C_P {}; class C_P_27 : C_P {}; class C_P_28 : C_P {}; class C_P_29 : C_P {}; class C_P_30 : C_P {}; class C_P_31 : C_P {}; class C_P_32 : C_P {}; class C_P_33 : C_P {}; class C_P_34 : C_P {}; class C_P_35 : C_P {}; class C_P_36 : C_P {}; class C_P_37 : C_P {}; class C_P_38 : C_P {}; class C_P_39 : C_P {}; class C_P_40 : C_P {}; class C_P_41 : C_P {}; class C_P_42 : C_P {}; class C_P_43 : C_P {}; class C_P_44 : C_P {}; class C_P_45 : C_P {}; class C_P_46 : C_P {}; class C_P_47 : C_P {}; class C_P_48 : C_P {}; class C_P_49 : C_P {}; class C_P_50 : C_P {};
-// ====================================================================================
+
 class C_PC {            // "PC"         | HELICOPTER CREW
     uniform         = "rhs_uniform_cu_ocp_1stcav";
     vest            = "rhsusf_iotv_ocp_Teamleader";
     headgear        = "H_CrewHelmetHeli_B";
-    nvgoggles       = rhsusf_ANPVS_15;
+    nvgoggles       = "rhsusf_ANPVS_15";
     backpack        = "";
     
     primaryWeapon   = _WEAPON_PRIMARY0;
@@ -132,7 +195,7 @@ class C_PC {            // "PC"         | HELICOPTER CREW
     items[] = {};
     magazines[] = {};
     addItemsToUniform[] = {
-        _QUA10(ACE_FieldDressing),
+        _QUA10(ACE_packingBandage),
         _QUA2(ACE_morphine),
         _QUA2(ACE_epinephrine),
         _QUA1(ACE_tourniquet),
@@ -166,13 +229,13 @@ class C_PC {            // "PC"         | HELICOPTER CREW
     watch           = "tf_microdagr";
 };
 class C_PC_1 : C_PC {}; class C_PC_2 : C_PC {}; class C_PC_3 : C_PC {}; class C_PC_4 : C_PC {}; class C_PC_5 : C_PC {}; class C_PC_6 : C_PC {}; class C_PC_7 : C_PC {}; class C_PC_8 : C_PC {}; class C_PC_9 : C_PC {}; class C_PC_10 : C_PC {}; class C_PC_11 : C_PC {}; class C_PC_12 : C_PC {}; class C_PC_13 : C_PC {}; class C_PC_14 : C_PC {}; class C_PC_15 : C_PC {}; class C_PC_16 : C_PC {}; class C_PC_17 : C_PC {}; class C_PC_18 : C_PC {}; class C_PC_19 : C_PC {}; class C_PC_20 : C_PC {}; class C_PC_21 : C_PC {}; class C_PC_22 : C_PC {}; class C_PC_23 : C_PC {}; class C_PC_24 : C_PC {}; class C_PC_25 : C_PC {}; class C_PC_26 : C_PC {}; class C_PC_27 : C_PC {}; class C_PC_28 : C_PC {}; class C_PC_29 : C_PC {}; class C_PC_30 : C_PC {}; class C_PC_31 : C_PC {}; class C_PC_32 : C_PC {}; class C_PC_33 : C_PC {}; class C_PC_34 : C_PC {}; class C_PC_35 : C_PC {}; class C_PC_36 : C_PC {}; class C_PC_37 : C_PC {}; class C_PC_38 : C_PC {}; class C_PC_39 : C_PC {}; class C_PC_40 : C_PC {}; class C_PC_41 : C_PC {}; class C_PC_42 : C_PC {}; class C_PC_43 : C_PC {}; class C_PC_44 : C_PC {}; class C_PC_45 : C_PC {}; class C_PC_46 : C_PC {}; class C_PC_47 : C_PC {}; class C_PC_48 : C_PC {}; class C_PC_49 : C_PC {}; class C_PC_50 : C_PC {};
-// ====================================================================================
-// ====================================================================================
+
+
 class C_PG {                  // "PG"        | PILOT G SUIT
     uniform         = "U_B_PilotCoveralls";
-    vest            = V_TacVest_blk;
+    vest            = "V_TacVest_blk";
     headgear        = "H_PilotHelmetFighter_B";
-    nvgoggles       = rhsusf_ANPVS_15;
+    nvgoggles       = "rhsusf_ANPVS_15";
     backpack        = "ACE_NonSteerableParachute";
     
     primaryWeapon   = _WEAPON_PRIMARY0;
@@ -186,7 +249,7 @@ class C_PG {                  // "PG"        | PILOT G SUIT
     items[] = {};
     magazines[] = {};
     addItemsToUniform[] = {
-        _QUA10(ACE_FieldDressing),
+        _QUA10(ACE_packingBandage),
         _QUA2(ACE_morphine),
         _QUA2(ACE_epinephrine),
         _QUA1(ACE_tourniquet),

--- a/cScripts/Loadouts/loadout_Sniper.hpp
+++ b/cScripts/Loadouts/loadout_Sniper.hpp
@@ -1,5 +1,5 @@
 /*
-GearVersionDate: 160303
+GearVersionDate: 160413
 */
 class C_SPT {                // "SPT"       | SPOTTER
     uniform         = "rhs_uniform_cu_ocp_1stcav";
@@ -22,7 +22,7 @@ class C_SPT {                // "SPT"       | SPOTTER
     items[] = {};
     magazines[] = {};
     addItemsToUniform[] = {
-        _QUA10(ACE_FieldDressing),
+        _QUA10(ACE_packingBandage),
         _QUA2(ACE_morphine),
         _QUA2(ACE_epinephrine),
         _QUA1(ACE_tourniquet),
@@ -71,7 +71,7 @@ class C_SPT {                // "SPT"       | SPOTTER
     watch           = "tf_microdagr";
 };
 class C_SPT_1 : C_SPT {}; class C_SPT_2 : C_SPT {}; class C_SPT_3 : C_SPT {}; class C_SPT_4 : C_SPT {}; class C_SPT_5 : C_SPT {}; class C_SPT_6 : C_SPT {}; class C_SPT_7 : C_SPT {}; class C_SPT_8 : C_SPT {}; class C_SPT_9 : C_SPT {}; class C_SPT_10 : C_SPT {}; class C_SPT_11 : C_SPT {}; class C_SPT_12 : C_SPT {}; class C_SPT_13 : C_SPT {}; class C_SPT_14 : C_SPT {}; class C_SPT_15 : C_SPT {}; class C_SPT_16 : C_SPT {}; class C_SPT_17 : C_SPT {}; class C_SPT_18 : C_SPT {}; class C_SPT_19 : C_SPT {}; class C_SPT_20 : C_SPT {}; class C_SPT_21 : C_SPT {}; class C_SPT_22 : C_SPT {}; class C_SPT_23 : C_SPT {}; class C_SPT_24 : C_SPT {}; class C_SPT_25 : C_SPT {}; class C_SPT_26 : C_SPT {}; class C_SPT_27 : C_SPT {}; class C_SPT_28 : C_SPT {}; class C_SPT_29 : C_SPT {}; class C_SPT_30 : C_SPT {}; class C_SPT_31 : C_SPT {}; class C_SPT_32 : C_SPT {}; class C_SPT_33 : C_SPT {}; class C_SPT_34 : C_SPT {}; class C_SPT_35 : C_SPT {}; class C_SPT_36 : C_SPT {}; class C_SPT_37 : C_SPT {}; class C_SPT_38 : C_SPT {}; class C_SPT_39 : C_SPT {}; class C_SPT_40 : C_SPT {}; class C_SPT_41 : C_SPT {}; class C_SPT_42 : C_SPT {}; class C_SPT_43 : C_SPT {}; class C_SPT_44 : C_SPT {}; class C_SPT_45 : C_SPT {}; class C_SPT_46 : C_SPT {}; class C_SPT_47 : C_SPT {}; class C_SPT_48 : C_SPT {}; class C_SPT_49 : C_SPT {}; class C_SPT_50 : C_SPT {};
-// ==================================================================================== 
+ 
 class C_SPTG {         // "SPTG"      | SPOTTER GHILLIE
     uniform         = "U_B_GhillieSuit";
     vest            = "rhsusf_iotv_ocp_Squadleader";
@@ -93,7 +93,7 @@ class C_SPTG {         // "SPTG"      | SPOTTER GHILLIE
     items[] = {};
     magazines[] = {};
     addItemsToUniform[] = {
-        _QUA10(ACE_FieldDressing),
+        _QUA10(ACE_packingBandage),
         _QUA2(ACE_morphine),
         _QUA2(ACE_epinephrine),
         _QUA1(ACE_tourniquet),
@@ -142,7 +142,7 @@ class C_SPTG {         // "SPTG"      | SPOTTER GHILLIE
     watch           = "tf_microdagr";
 };
 class C_SPTG_1 : C_SPTG {}; class C_SPTG_2 : C_SPTG {}; class C_SPTG_3 : C_SPTG {}; class C_SPTG_4 : C_SPTG {}; class C_SPTG_5 : C_SPTG {}; class C_SPTG_6 : C_SPTG {}; class C_SPTG_7 : C_SPTG {}; class C_SPTG_8 : C_SPTG {}; class C_SPTG_9 : C_SPTG {}; class C_SPTG_10 : C_SPTG {}; class C_SPTG_11 : C_SPTG {}; class C_SPTG_12 : C_SPTG {}; class C_SPTG_13 : C_SPTG {}; class C_SPTG_14 : C_SPTG {}; class C_SPTG_15 : C_SPTG {}; class C_SPTG_16 : C_SPTG {}; class C_SPTG_17 : C_SPTG {}; class C_SPTG_18 : C_SPTG {}; class C_SPTG_19 : C_SPTG {}; class C_SPTG_20 : C_SPTG {}; class C_SPTG_21 : C_SPTG {}; class C_SPTG_22 : C_SPTG {}; class C_SPTG_23 : C_SPTG {}; class C_SPTG_24 : C_SPTG {}; class C_SPTG_25 : C_SPTG {}; class C_SPTG_26 : C_SPTG {}; class C_SPTG_27 : C_SPTG {}; class C_SPTG_28 : C_SPTG {}; class C_SPTG_29 : C_SPTG {}; class C_SPTG_30 : C_SPTG {}; class C_SPTG_31 : C_SPTG {}; class C_SPTG_32 : C_SPTG {}; class C_SPTG_33 : C_SPTG {}; class C_SPTG_34 : C_SPTG {}; class C_SPTG_35 : C_SPTG {}; class C_SPTG_36 : C_SPTG {}; class C_SPTG_37 : C_SPTG {}; class C_SPTG_38 : C_SPTG {}; class C_SPTG_39 : C_SPTG {}; class C_SPTG_40 : C_SPTG {}; class C_SPTG_41 : C_SPTG {}; class C_SPTG_42 : C_SPTG {}; class C_SPTG_43 : C_SPTG {}; class C_SPTG_44 : C_SPTG {}; class C_SPTG_45 : C_SPTG {}; class C_SPTG_46 : C_SPTG {}; class C_SPTG_47 : C_SPTG {}; class C_SPTG_48 : C_SPTG {}; class C_SPTG_49 : C_SPTG {}; class C_SPTG_50 : C_SPTG {};
-// ==================================================================================== 
+ 
 class C_SNP {                 // "SNP"       | SNIPER
     uniform         = "rhs_uniform_cu_ocp_1stcav";
     vest            = "rhsusf_iotv_ocp_Squadleader";
@@ -164,7 +164,7 @@ class C_SNP {                 // "SNP"       | SNIPER
     items[] = {};
     magazines[] = {};
     addItemsToUniform[] = {
-        _QUA10(ACE_FieldDressing),
+        _QUA10(ACE_packingBandage),
         _QUA2(ACE_morphine),
         _QUA2(ACE_epinephrine),
         _QUA1(ACE_tourniquet),
@@ -213,7 +213,7 @@ class C_SNP {                 // "SNP"       | SNIPER
     watch           = "tf_microdagr";
 };
 class C_SNP_1 : C_SNP {}; class C_SNP_2 : C_SNP {}; class C_SNP_3 : C_SNP {}; class C_SNP_4 : C_SNP {}; class C_SNP_5 : C_SNP {}; class C_SNP_6 : C_SNP {}; class C_SNP_7 : C_SNP {}; class C_SNP_8 : C_SNP {}; class C_SNP_9 : C_SNP {}; class C_SNP_10 : C_SNP {}; class C_SNP_11 : C_SNP {}; class C_SNP_12 : C_SNP {}; class C_SNP_13 : C_SNP {}; class C_SNP_14 : C_SNP {}; class C_SNP_15 : C_SNP {}; class C_SNP_16 : C_SNP {}; class C_SNP_17 : C_SNP {}; class C_SNP_18 : C_SNP {}; class C_SNP_19 : C_SNP {}; class C_SNP_20 : C_SNP {}; class C_SNP_21 : C_SNP {}; class C_SNP_22 : C_SNP {}; class C_SNP_23 : C_SNP {}; class C_SNP_24 : C_SNP {}; class C_SNP_25 : C_SNP {}; class C_SNP_26 : C_SNP {}; class C_SNP_27 : C_SNP {}; class C_SNP_28 : C_SNP {}; class C_SNP_29 : C_SNP {}; class C_SNP_30 : C_SNP {}; class C_SNP_31 : C_SNP {}; class C_SNP_32 : C_SNP {}; class C_SNP_33 : C_SNP {}; class C_SNP_34 : C_SNP {}; class C_SNP_35 : C_SNP {}; class C_SNP_36 : C_SNP {}; class C_SNP_37 : C_SNP {}; class C_SNP_38 : C_SNP {}; class C_SNP_39 : C_SNP {}; class C_SNP_40 : C_SNP {}; class C_SNP_41 : C_SNP {}; class C_SNP_42 : C_SNP {}; class C_SNP_43 : C_SNP {}; class C_SNP_44 : C_SNP {}; class C_SNP_45 : C_SNP {}; class C_SNP_46 : C_SNP {}; class C_SNP_47 : C_SNP {}; class C_SNP_48 : C_SNP {}; class C_SNP_49 : C_SNP {}; class C_SNP_50 : C_SNP {};
-// ==================================================================================== 
+ 
 class C_SNPG {         // "SNPG"       | SNIPER GHILLIE
     uniform         = "U_B_GhillieSuit";
     vest            = "rhsusf_iotv_ocp_Squadleader";
@@ -235,7 +235,7 @@ class C_SNPG {         // "SNPG"       | SNIPER GHILLIE
     items[] = {};
     magazines[] = {};
     addItemsToUniform[] = {
-        _QUA10(ACE_FieldDressing),
+        _QUA10(ACE_packingBandage),
         _QUA2(ACE_morphine),
         _QUA2(ACE_epinephrine),
         _QUA1(ACE_tourniquet),
@@ -284,4 +284,3 @@ class C_SNPG {         // "SNPG"       | SNIPER GHILLIE
     watch           = "tf_microdagr";
 };
 class C_SNPG_1 : C_SNPG {}; class C_SNPG_2 : C_SNPG {}; class C_SNPG_3 : C_SNPG {}; class C_SNPG_4 : C_SNPG {}; class C_SNPG_5 : C_SNPG {}; class C_SNPG_6 : C_SNPG {}; class C_SNPG_7 : C_SNPG {}; class C_SNPG_8 : C_SNPG {}; class C_SNPG_9 : C_SNPG {}; class C_SNPG_10 : C_SNPG {}; class C_SNPG_11 : C_SNPG {}; class C_SNPG_12 : C_SNPG {}; class C_SNPG_13 : C_SNPG {}; class C_SNPG_14 : C_SNPG {}; class C_SNPG_15 : C_SNPG {}; class C_SNPG_16 : C_SNPG {}; class C_SNPG_17 : C_SNPG {}; class C_SNPG_18 : C_SNPG {}; class C_SNPG_19 : C_SNPG {}; class C_SNPG_20 : C_SNPG {}; class C_SNPG_21 : C_SNPG {}; class C_SNPG_22 : C_SNPG {}; class C_SNPG_23 : C_SNPG {}; class C_SNPG_24 : C_SNPG {}; class C_SNPG_25 : C_SNPG {}; class C_SNPG_26 : C_SNPG {}; class C_SNPG_27 : C_SNPG {}; class C_SNPG_28 : C_SNPG {}; class C_SNPG_29 : C_SNPG {}; class C_SNPG_30 : C_SNPG {}; class C_SNPG_31 : C_SNPG {}; class C_SNPG_32 : C_SNPG {}; class C_SNPG_33 : C_SNPG {}; class C_SNPG_34 : C_SNPG {}; class C_SNPG_35 : C_SNPG {}; class C_SNPG_36 : C_SNPG {}; class C_SNPG_37 : C_SNPG {}; class C_SNPG_38 : C_SNPG {}; class C_SNPG_39 : C_SNPG {}; class C_SNPG_40 : C_SNPG {}; class C_SNPG_41 : C_SNPG {}; class C_SNPG_42 : C_SNPG {}; class C_SNPG_43 : C_SNPG {}; class C_SNPG_44 : C_SNPG {}; class C_SNPG_45 : C_SNPG {}; class C_SNPG_46 : C_SNPG {}; class C_SNPG_47 : C_SNPG {}; class C_SNPG_48 : C_SNPG {}; class C_SNPG_49 : C_SNPG {}; class C_SNPG_50 : C_SNPG {};
-// ====================================================================================

--- a/cScripts/Loadouts/loadout_Training.hpp
+++ b/cScripts/Loadouts/loadout_Training.hpp
@@ -36,7 +36,7 @@ class C_CAD {       // "CAD"       | CADRE
     watch           = "";
 };
 class C_CAD_1 : C_CAD {}; class C_CAD_2 : C_CAD {}; class C_CAD_3 : C_CAD {}; class C_CAD_4 : C_CAD {}; class C_CAD_5 : C_CAD {}; class C_CAD_6 : C_CAD {}; class C_CAD_7 : C_CAD {}; class C_CAD_8 : C_CAD {}; class C_CAD_9 : C_CAD {}; class C_CAD_10 : C_CAD {}; class C_CAD_11 : C_CAD {}; class C_CAD_12 : C_CAD {}; class C_CAD_13 : C_CAD {}; class C_CAD_14 : C_CAD {}; class C_CAD_15 : C_CAD {}; class C_CAD_16 : C_CAD {}; class C_CAD_17 : C_CAD {}; class C_CAD_18 : C_CAD {}; class C_CAD_19 : C_CAD {}; class C_CAD_20 : C_CAD {}; class C_CAD_21 : C_CAD {}; class C_CAD_22 : C_CAD {}; class C_CAD_23 : C_CAD {}; class C_CAD_24 : C_CAD {}; class C_CAD_25 : C_CAD {}; class C_CAD_26 : C_CAD {}; class C_CAD_27 : C_CAD {}; class C_CAD_28 : C_CAD {}; class C_CAD_29 : C_CAD {}; class C_CAD_30 : C_CAD {}; class C_CAD_31 : C_CAD {}; class C_CAD_32 : C_CAD {}; class C_CAD_33 : C_CAD {}; class C_CAD_34 : C_CAD {}; class C_CAD_35 : C_CAD {}; class C_CAD_36 : C_CAD {}; class C_CAD_37 : C_CAD {}; class C_CAD_38 : C_CAD {}; class C_CAD_39 : C_CAD {}; class C_CAD_40 : C_CAD {}; class C_CAD_41 : C_CAD {}; class C_CAD_42 : C_CAD {}; class C_CAD_43 : C_CAD {}; class C_CAD_44 : C_CAD {}; class C_CAD_45 : C_CAD {}; class C_CAD_46 : C_CAD {}; class C_CAD_47 : C_CAD {}; class C_CAD_48 : C_CAD {}; class C_CAD_49 : C_CAD {}; class C_CAD_50 : C_CAD {};
-// ====================================================================================
+
 class C_DI {        // "DI"        | DRILL INSTRUCTOR
     uniform         = "rhs_uniform_cu_ocp_1stcav";
     vest            = "V_BandollierB_rgr";
@@ -72,7 +72,7 @@ class C_DI {        // "DI"        | DRILL INSTRUCTOR
     watch           = "";
 };
 class C_DI_1 : C_DI {}; class C_DI_2 : C_DI {}; class C_DI_3 : C_DI {}; class C_DI_4 : C_DI {}; class C_DI_5 : C_DI {}; class C_DI_6 : C_DI {}; class C_DI_7 : C_DI {}; class C_DI_8 : C_DI {}; class C_DI_9 : C_DI {}; class C_DI_10 : C_DI {}; class C_DI_11 : C_DI {}; class C_DI_12 : C_DI {}; class C_DI_13 : C_DI {}; class C_DI_14 : C_DI {}; class C_DI_15 : C_DI {}; class C_DI_16 : C_DI {}; class C_DI_17 : C_DI {}; class C_DI_18 : C_DI {}; class C_DI_19 : C_DI {}; class C_DI_20 : C_DI {}; class C_DI_21 : C_DI {}; class C_DI_22 : C_DI {}; class C_DI_23 : C_DI {}; class C_DI_24 : C_DI {}; class C_DI_25 : C_DI {}; class C_DI_26 : C_DI {}; class C_DI_27 : C_DI {}; class C_DI_28 : C_DI {}; class C_DI_29 : C_DI {}; class C_DI_30 : C_DI {}; class C_DI_31 : C_DI {}; class C_DI_32 : C_DI {}; class C_DI_33 : C_DI {}; class C_DI_34 : C_DI {}; class C_DI_35 : C_DI {}; class C_DI_36 : C_DI {}; class C_DI_37 : C_DI {}; class C_DI_38 : C_DI {}; class C_DI_39 : C_DI {}; class C_DI_40 : C_DI {}; class C_DI_41 : C_DI {}; class C_DI_42 : C_DI {}; class C_DI_43 : C_DI {}; class C_DI_44 : C_DI {}; class C_DI_45 : C_DI {}; class C_DI_46 : C_DI {}; class C_DI_47 : C_DI {}; class C_DI_48 : C_DI {}; class C_DI_49 : C_DI {}; class C_DI_50 : C_DI {};
-// ====================================================================================
+
 class C_TRP {       // "TRP"       | TROOPER
     uniform         = "rhs_uniform_cu_ocp_1stcav";
     vest            = "rhsusf_iotv_ocp_Rifleman";
@@ -108,4 +108,4 @@ class C_TRP {       // "TRP"       | TROOPER
     watch           = "";
 };
 class C_TRP_1 : C_TRP {}; class C_TRP_2 : C_TRP {}; class C_TRP_3 : C_TRP {}; class C_TRP_4 : C_TRP {}; class C_TRP_5 : C_TRP {}; class C_TRP_6 : C_TRP {}; class C_TRP_7 : C_TRP {}; class C_TRP_8 : C_TRP {}; class C_TRP_9 : C_TRP {}; class C_TRP_10 : C_TRP {}; class C_TRP_11 : C_TRP {}; class C_TRP_12 : C_TRP {}; class C_TRP_13 : C_TRP {}; class C_TRP_14 : C_TRP {}; class C_TRP_15 : C_TRP {}; class C_TRP_16 : C_TRP {}; class C_TRP_17 : C_TRP {}; class C_TRP_18 : C_TRP {}; class C_TRP_19 : C_TRP {}; class C_TRP_20 : C_TRP {}; class C_TRP_21 : C_TRP {}; class C_TRP_22 : C_TRP {}; class C_TRP_23 : C_TRP {}; class C_TRP_24 : C_TRP {}; class C_TRP_25 : C_TRP {}; class C_TRP_26 : C_TRP {}; class C_TRP_27 : C_TRP {}; class C_TRP_28 : C_TRP {}; class C_TRP_29 : C_TRP {}; class C_TRP_30 : C_TRP {}; class C_TRP_31 : C_TRP {}; class C_TRP_32 : C_TRP {}; class C_TRP_33 : C_TRP {}; class C_TRP_34 : C_TRP {}; class C_TRP_35 : C_TRP {}; class C_TRP_36 : C_TRP {}; class C_TRP_37 : C_TRP {}; class C_TRP_38 : C_TRP {}; class C_TRP_39 : C_TRP {}; class C_TRP_40 : C_TRP {}; class C_TRP_41 : C_TRP {}; class C_TRP_42 : C_TRP {}; class C_TRP_43 : C_TRP {}; class C_TRP_44 : C_TRP {}; class C_TRP_45 : C_TRP {}; class C_TRP_46 : C_TRP {}; class C_TRP_47 : C_TRP {}; class C_TRP_48 : C_TRP {}; class C_TRP_49 : C_TRP {}; class C_TRP_50 : C_TRP {};
-// ====================================================================================
+


### PR DESCRIPTION
- All field dressing replaced with packing bandages
- Removed quick clot from combat lifesavers, replaced with additional packing/elastic bandages
- Added MicroDAGR (replacing DAGR), Vector, M4 M320 +HE/HEDP/SMK shells and colored smoke to Tank Commander
- Replaced Rifleman vest with Grenadier vest for Tank Commander
- Added binoculars to Tank crewman
- Replaced PVS14 NVGs with PVS15 NVGs for Tank Crewman and Tank Commander
- Removed ACOGs from Tank Crewman and Tank Commander
- Added android device for tank crewman
- Updated gearversion date for loadout_common and loadout_crew to 160413
- Added `C_ARL` and `C_ARM` (Close #8)
- Removed `//====` lines
- Moved Tank Commander to loadout_Crew
- Moved all AT and AA to the bottom of loadout_Common